### PR TITLE
enables gzip accept_encoding gzip for pull operation

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -103,8 +103,9 @@ class BazaRb
             home.append('pull').append("#{id}.fb").to_s,
             method: :get,
             headers: headers.merge(
-              'Accept' => 'application/octet-stream'
+              'Accept' => 'application/zip, application/factbase'
             ),
+            accept_encoding: 'gzip',
             connecttimeout: @timeout,
             timeout: @timeout
           )


### PR DESCRIPTION
required for https://github.com/yegor256/judges/issues/84

Not providing a test here because:

- test with webmock is impossible as it patches typhous on a higher level than this parameter starts working (libcurl)
- test with a real server would require a more sophisticated server than currently used
- such a test would test the [capability of the typhous library](https://github.com/typhoeus/typhoeus/tree/master?tab=readme-ov-file#compression) per se