### PR TITLE
feat(#122): retry on anything

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -676,7 +676,7 @@ class BazaRb
     attempt = 0
     loop do
       ret = yield
-      if ret.code == 429 || ret.code >= 500 && attempt < @retries
+      if (ret.code == 429 || ret.code >= 500) && attempt < @retries
         attempt += 1
         seconds = 2 * @pause * attempt
         @loog.info("Server seems to be in trouble, will sleep for #{seconds} (attempt no.#{attempt})...")

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -676,9 +676,9 @@ class BazaRb
     attempt = 0
     loop do
       ret = yield
-      if ret.code >= 500 && attempt < @retries
+      if ret.code.between?(429, 500) && attempt < @retries
         attempt += 1
-        seconds = @pause * (2**attempt)
+        seconds = 2 * @pause * attempt
         @loog.info("Server seems to be in trouble, will sleep for #{seconds} (attempt no.#{attempt})...")
         sleep(seconds)
         next

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -676,7 +676,7 @@ class BazaRb
     attempt = 0
     loop do
       ret = yield
-      if ret.code.between?(429, 500) && attempt < @retries
+      if ret.code.between?(429, 599) && attempt < @retries
         attempt += 1
         seconds = 2 * @pause * attempt
         @loog.info("Server seems to be in trouble, will sleep for #{seconds} (attempt no.#{attempt})...")

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -649,11 +649,11 @@ class BazaRb
     with_retries(max_tries: @retries, rescue: TimedOut, &)
   end
 
-  # @todo #122:30min All `retry_with_**` methods can be replaced.
-  #  If we want to handle bulk of cases when some error code is ocurred,
-  #  now wee need to add separate method instead of using some _generic_
-  #  solution. I suggest add method like `retry_on(arrange, message, attempts)`.
-  #  Usage will look like `retry_on(400..429, "My errror message", 3)`.
+  # @todo #122:30min Replace all `retry_with_**` methods.
+  #  Currently, if we want to handle a range of error codes, we have to add a
+  #  separate method for each case instead of using a generic solution.
+  #  I suggest adding a method like `retry_on(range, message, attempts)`.
+  #  Example usage: `retry_on(400..429, "My error message", 3)`.
   #
   # Execute a block with retries on 429 status codes.
   #

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -649,6 +649,12 @@ class BazaRb
     with_retries(max_tries: @retries, rescue: TimedOut, &)
   end
 
+  # @todo #122:30min All `retry_with_**` methods can be replaced.
+  #  If we want to handle bulk of cases when some error code is ocurred,
+  #  now wee need to add separate method instead of using some _generic_
+  #  solution. I suggest add method like `retry_on(arrange, message, attempts)`.
+  #  Usage will look like `retry_on(400..429, "My errror message", 3)`.
+  #
   # Execute a block with retries on 429 status codes.
   #
   # @yield The block to execute with retries

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -676,7 +676,7 @@ class BazaRb
     attempt = 0
     loop do
       ret = yield
-      if ret.code.between?(429, 599) && attempt < @retries
+      if ret.code == 429 || ret.code >= 500 && attempt < @retries
         attempt += 1
         seconds = 2 * @pause * attempt
         @loog.info("Server seems to be in trouble, will sleep for #{seconds} (attempt no.#{attempt})...")

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -898,12 +898,10 @@ class BazaRb
           retry_it do
             checked(
               retry_if_server_failed do
-                retry_if_server_busy do
-                  Typhoeus::Request.put(
-                    uri.to_s,
-                    params
-                  )
-                end
+                Typhoeus::Request.put(
+                  uri.to_s,
+                  params
+                )
               end
             )
           end

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -668,6 +668,25 @@ class BazaRb
     end
   end
 
+  # Execute a block with retries on 499 status codes.
+  #
+  # @yield The block to execute with retries
+  # @return [Object] The result of the block execution
+  def retry_if_connection_closed(&)
+    attempt = 0
+    loop do
+      ret = yield
+      if ret.code == 499 && attempt < @retries
+        attempt += 1
+        seconds = @pause * (2**attempt)
+        @loog.info("Connection seems to be closed, will sleep for #{seconds} (attempt no.#{attempt})...")
+        sleep(seconds)
+        next
+      end
+      return ret
+    end
+  end
+
   # Execute a block with retries on 500 status codes.
   #
   # @yield The block to execute with retries
@@ -676,9 +695,9 @@ class BazaRb
     attempt = 0
     loop do
       ret = yield
-      if (ret.code == 429 || ret.code >= 500) && attempt < @retries
+      if ret.code >= 500 && attempt < @retries
         attempt += 1
-        seconds = 2 * @pause * attempt
+        seconds = @pause * (2**attempt)
         @loog.info("Server seems to be in trouble, will sleep for #{seconds} (attempt no.#{attempt})...")
         sleep(seconds)
         next
@@ -897,11 +916,15 @@ class BazaRb
         ret =
           retry_it do
             checked(
-              retry_if_server_failed do
-                Typhoeus::Request.put(
-                  uri.to_s,
-                  params
-                )
+              retry_if_server_busy do
+                retry_if_connection_closed do
+                  retry_if_server_failed do
+                    Typhoeus::Request.put(
+                      uri.to_s,
+                      params
+                    )
+                  end
+                end
               end
             )
           end

--- a/test/test_baza-rb.rb
+++ b/test/test_baza-rb.rb
@@ -737,18 +737,17 @@ class TestBazaRb < Minitest::Test
     end
   end
 
-  def test_upload_retries_on_failing_server
+  def test_upload_retries_on_closed_connection
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|
       file = File.join(dir, 'upload.txt')
       File.write(file, 'test content')
       attempts = 0
-      codes = [429, 500]
       stub_request(:put, 'https://example.org:443/file')
         .to_return do |_request|
           attempts += 1
           if attempts < 2
-            { status: codes[attempts - 1], body: 'Internal Error!' }
+            { status: 499, body: 'Internal Error!' }
           else
             { status: 200, body: 'OK' }
           end

--- a/test/test_baza-rb.rb
+++ b/test/test_baza-rb.rb
@@ -737,6 +737,28 @@ class TestBazaRb < Minitest::Test
     end
   end
 
+  def test_upload_retries_on_failing_server
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'upload.txt')
+      File.write(file, 'test content')
+      attempts = 0
+      code = 429
+      stub_request(:put, 'https://example.org:443/file')
+        .to_return do |_request|
+          attempts += 1
+          if attempts < 2
+            { status: code += 1, body: 'Too Many Requests' }
+          else
+            { status: 200, body: 'OK' }
+          end
+        end
+      baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, timeout: 0.1, pause: 0)
+      baza.send(:upload, baza.send(:home).append('file'), file)
+      assert_equal(2, attempts, 'Expected 2 HTTP calls due to 429 retries')
+    end
+  end
+
   def test_durable_load_from_sinatra
     WebMock.enable_net_connect!
     Dir.mktmpdir do |dir|

--- a/test/test_baza-rb.rb
+++ b/test/test_baza-rb.rb
@@ -743,7 +743,7 @@ class TestBazaRb < Minitest::Test
       file = File.join(dir, 'upload.txt')
       File.write(file, 'test content')
       attempts = 0
-      codes = [499, 500]
+      codes = [429, 500]
       stub_request(:put, 'https://example.org:443/file')
         .to_return do |_request|
           attempts += 1

--- a/test/test_baza-rb.rb
+++ b/test/test_baza-rb.rb
@@ -743,12 +743,12 @@ class TestBazaRb < Minitest::Test
       file = File.join(dir, 'upload.txt')
       File.write(file, 'test content')
       attempts = 0
-      code = 499
+      codes = [499, 500]
       stub_request(:put, 'https://example.org:443/file')
         .to_return do |_request|
           attempts += 1
           if attempts < 2
-            { status: code += 1, body: 'Internal Error!' }
+            { status: codes[attempts - 1], body: 'Internal Error!' }
           else
             { status: 200, body: 'OK' }
           end

--- a/test/test_baza-rb.rb
+++ b/test/test_baza-rb.rb
@@ -743,19 +743,19 @@ class TestBazaRb < Minitest::Test
       file = File.join(dir, 'upload.txt')
       File.write(file, 'test content')
       attempts = 0
-      code = 429
+      code = 499
       stub_request(:put, 'https://example.org:443/file')
         .to_return do |_request|
           attempts += 1
           if attempts < 2
-            { status: code += 1, body: 'Too Many Requests' }
+            { status: code += 1, body: 'Internal Error!' }
           else
             { status: 200, body: 'OK' }
           end
         end
       baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, timeout: 0.1, pause: 0)
       baza.send(:upload, baza.send(:home).append('file'), file)
-      assert_equal(2, attempts, 'Expected 2 HTTP calls due to 429, 430 retries')
+      assert_equal(2, attempts, 'Expected 2 HTTP calls due to 499, 500 retries')
     end
   end
 

--- a/test/test_baza-rb.rb
+++ b/test/test_baza-rb.rb
@@ -755,7 +755,7 @@ class TestBazaRb < Minitest::Test
         end
       baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, timeout: 0.1, pause: 0)
       baza.send(:upload, baza.send(:home).append('file'), file)
-      assert_equal(2, attempts, 'Expected 2 HTTP calls due to 429 retries')
+      assert_equal(2, attempts, 'Expected 2 HTTP calls due to 429, 430 retries')
     end
   end
 


### PR DESCRIPTION
@yegor256 take a look, please 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Upload retry flow updated to add a dedicated path for handling connection-closed (499) responses alongside rate-limit (429) and server errors, and to adjust the retry wrapping order and control flow during uploads.
  * Backoff behavior preserved for consistent retries.

* **Tests**
  * Added a test verifying an upload retries once after an initial connection-closed (499) response and succeeds on retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->