### PR TITLE
Retry on 499 (Client Closed Request) like 5xx (#122)

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -659,7 +659,13 @@ class BazaRb
     end
   end
 
-  # Execute a block with retries on 500 status codes.
+  # Execute a block with retries on server-side failures.
+  #
+  # Retries on any HTTP status >= 499. The 499 code ("Client Closed Request")
+  # is emitted by upstream proxies such as nginx when they abort an in-flight
+  # request, typically because of a load-balancer or upstream timeout. From
+  # the client's point of view this is a transient server-side failure and
+  # should be retried just like 5xx responses.
   #
   # @yield The block to execute with retries
   # @return [Object] The result of the block execution
@@ -667,7 +673,7 @@ class BazaRb
     attempt = 0
     loop do
       ret = yield
-      if ret.code >= 500 && attempt < @retries
+      if ret.code >= 499 && attempt < @retries
         attempt += 1
         seconds = @pause * (2**attempt)
         @loog.info("Server seems to be in trouble (#{ret.code}), sleep #{seconds}s (attempt no.#{attempt})...")

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -299,6 +299,31 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  # Reproduces zerocracy/baza.rb#122: when an upstream proxy aborts an in-flight
+  # request (e.g. nginx returns 499 "Client Closed Request" after a load-balancer
+  # timeout), the failure is server-side from the client's point of view and
+  # should be retried, just like 5xx responses.
+  def test_upload_retries_on_499_failure
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'upload.txt')
+      File.write(file, 'test content')
+      attempts = 0
+      stub_request(:put, 'https://example.org:443/file')
+        .to_return do |_request|
+          attempts += 1
+          if attempts < 2
+            { status: 499, body: 'Client Closed Request' }
+          else
+            { status: 200, body: 'OK' }
+          end
+        end
+      baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, timeout: 0.1, pause: 0)
+      baza.send(:upload, baza.send(:home).append('file'), file)
+      assert_equal(2, attempts, 'Expected 2 HTTP calls due to 499 retries')
+    end
+  end
+
   # Reproduces zerocracy/baza.rb#111: when libcurl reports a transport-level
   # failure such as CURLE_PARTIAL_FILE (HTTP code 0, Typhoeus return_code
   # :partial_file), BazaRb#checked must raise something that BazaRb#retry_it


### PR DESCRIPTION
@yegor256 — closes #122.

## What was wrong

The upload trace in #122 (`E: Invalid response code #499 at PUT https://api.zerocracy.com/durables/458` followed by `Failed in 1m40s`) shows the upload aborting on the very first transient failure instead of retrying. Tracing through the code:

- Upstream proxies (nginx in front of `api.zerocracy.com`) emit `499 Client Closed Request` when they abort an in-flight request after a load-balancer / upstream timeout. From the client's point of view this is a transient server-side failure.
- `BazaRb#retry_if_server_failed` only retried on `ret.code >= 500`, so a `499` short-circuited past it.
- `BazaRb#checked` then raised `BazaRb::ServerFailure` because `499` is not in `allowed`.
- `BazaRb#retry_it` is `with_retries(rescue: TimedOut, ...)`, so `ServerFailure` propagated up and the whole upload failed without ever retrying.

## What changed

- **`lib/baza-rb.rb`** — lower the retry threshold in `retry_if_server_failed` from `>= 500` to `>= 499`, so the existing exponential-backoff loop covers `499` too. Updated the doc comment to spell out the rationale.
- **`test/test_baza_edge.rb`** — new `test_upload_retries_on_499_failure`: a WebMock test that stubs `PUT` to return `499` once and `200` next, then asserts `upload` succeeds with two HTTP attempts. Without the fix it reproduces the exact stack trace from the issue (`BazaRb::ServerFailure: Invalid response code #499 ... at lib/baza-rb.rb:731:in checked`); with the fix it passes.

## Commits

1. `test(#122): reproduce upload abort on 499 response` — failing WebMock test demonstrating the bug.
2. `fix(#122): retry on 499 (Client Closed Request) like 5xx` — one-character change to the retry threshold plus an updated doc comment.

## Verification

- `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n test_upload_retries_on_499_failure` — passes after the fix, fails before it with the exact issue trace.
- `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb` — every WebMock-based test still passes; no behaviour change for any other status code.
- `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` — no offenses.
- All 10 GitHub Actions checks on this PR (rake on ubuntu-24.04 and macos-15, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint) are green.

Ready for merge whenever you are.