### PR TITLE
#269: raise on empty owner in BazaRb#lock

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -231,6 +231,7 @@ class BazaRb
     raise 'The "pname" of the product is nil' if pname.nil?
     raise 'The "pname" of the product may not be empty' if pname.empty?
     raise 'The "owner" of the lock is nil' if owner.nil?
+    raise 'The "owner" of the lock may not be empty' if owner.empty?
     elapsed(@loog, level: Logger::INFO) do
       ret = post(
         home.append('lock').append(pname),

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -447,6 +447,11 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_lock_raises_when_owner_is_empty
+    error = assert_raises(RuntimeError) { fake_baza.lock('pname', '') }
+    assert_equal('The "owner" of the lock may not be empty', error.message)
+  end
+
   def test_upload_switches_host_mid_chunks
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
@yegor256 — closes #269.

## Why
`BazaRb#lock` was the only one of the four lock-style methods missing the empty-owner guard:

| method            | guards `owner.nil?` | guards `owner.empty?` |
|-------------------|---------------------|------------------------|
| `lock`            | yes                 | **no** (this PR adds it) |
| `unlock`          | yes                 | yes                    |
| `durable_lock`    | yes                 | yes                    |
| `durable_unlock`  | yes                 | yes                    |

So `lock('product', '')` silently passed client-side validation and proceeded to the HTTP layer, while `unlock('product', '')` raised `RuntimeError` immediately — an inconsistency the issue reporter flagged.

## What changed
- `lib/baza-rb.rb` — one line: `raise 'The "owner" of the lock may not be empty' if owner.empty?` after the existing `owner.nil?` guard. Wording matches verbatim the message used by the other three methods, so callers that already rescue this error message keep working.
- `test/test_baza_edge.rb` — new `test_lock_raises_when_owner_is_empty` regression test that calls `fake_baza.lock('pname', '')` and asserts the same `RuntimeError` and message that `unlock` already raises. The test fails on master and passes with the one-line fix; the two commits are split so the failing test is reproducible by checking out the first commit alone.

## CI
All 10 GitHub Actions checks are green: `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `rake (ubuntu-24.04, 3.3)`, `rake (macos-15, 3.3)`, `reuse`, `typos`, `xcop`, `yamllint`. The third-party `License Compliance` (FOSSA) status reports `error: 1 issues found` on master and other recent PRs (#270, #261) — it's a pre-existing repo-wide false positive, not introduced by this change.