### PR TITLE
Fix #109: restart upload after server reboot mid-chunks

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -867,6 +867,14 @@ class BazaRb
 
   # Upload file via PUT, using chunked uploads for large files.
   #
+  # If the server replies with a 4xx that contains an "Expecting chunk #N"
+  # hint (e.g. `X-Zerocracy-Flash: Expecting chunk #0 (0b are here),
+  # received #25`), the upload is rewound to chunk N and retried, instead
+  # of failing the whole pipeline. This typically happens after a server
+  # reboot in the middle of a multi-chunk upload (see #109). The number of
+  # such rewinds is bounded by the same `retries` setting as transport
+  # failures.
+  #
   # @param [Iri] uri The URI to upload to
   # @param [String] file The local file path to upload from
   # @param [Hash] extra Hash of extra HTTP headers to include
@@ -883,6 +891,7 @@ class BazaRb
     total = File.size(file)
     chunk = 0
     sent = 0
+    rewinds = 0
     elapsed(@loog, level: Logger::INFO) do
       loop do
         slice =
@@ -898,19 +907,34 @@ class BazaRb
         params[:body] = slice
         params[:headers]['Content-Length'] = slice.bytesize.to_s
         params = zipped(params) if @compress
-        ret =
-          retry_it do
-            checked(
-              retry_if_server_failed do
-                retry_if_server_busy do
-                  Typhoeus::Request.put(
-                    uri.to_s,
-                    params
-                  )
+        begin
+          ret =
+            retry_it do
+              checked(
+                retry_if_server_failed do
+                  retry_if_server_busy do
+                    Typhoeus::Request.put(
+                      uri.to_s,
+                      params
+                    )
+                  end
                 end
-              end
-            )
-          end
+              )
+            end
+        rescue BazaRb::ServerFailure => e
+          match = e.message.match(/Expecting chunk #(\d+)/)
+          raise if match.nil?
+          rewinds += 1
+          raise if rewinds > @retries
+          target = match[1].to_i
+          @loog.info(
+            "Server lost upload state at chunk ##{chunk}, " \
+            "restarting from chunk ##{target} (rewind no.#{rewinds})"
+          )
+          chunk = target
+          sent = 0
+          next
+        end
         uri = stick_host(ret, uri)
         sent += params[:body].bytesize
         @loog.debug(

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -485,6 +485,46 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  # Reproduces zerocracy/baza.rb#109: when the server is rebooted in the
+  # middle of a chunked upload, it loses the partial state and on the next
+  # PUT replies "400 Bad Request" with an "Expecting chunk #N" hint in the
+  # `X-Zerocracy-Flash` header. The client should restart the upload from
+  # the chunk the server is asking for, instead of aborting the whole job.
+  def test_upload_restarts_when_server_loses_chunk_state
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'large.txt')
+      File.write(file, 'x' * 2_000_000)
+      received = []
+      rebooted = false
+      stub_request(:put, 'https://example.org:443/file')
+        .to_return do |request|
+          chunk = request.headers['X-Zerocracy-Chunk']
+          received << chunk
+          if chunk == '1' && !rebooted
+            rebooted = true
+            {
+              status: 400,
+              headers: {
+                'X-Zerocracy-Flash' => 'Expecting chunk #0 (0b are here), received #1'
+              }
+            }
+          else
+            { status: 200, body: 'OK' }
+          end
+        end
+      baza = BazaRb.new(
+        'example.org', 443, '000',
+        loog: Loog::NULL, compress: false, retries: 2, pause: 0
+      )
+      baza.send(:upload, baza.send(:home).append('file'), file, {}, chunk_size: 1_000_000)
+      assert_equal(
+        %w[0 1 0 1], received,
+        'Expected the client to restart the upload from chunk #0 after the reboot'
+      )
+    end
+  end
+
   private
 
   def with_sinatra_server

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -526,6 +526,86 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  # Covers the `raise if match.nil?` exit of the upload rescue block: when the
+  # server replies "400 Bad Request" with a flash that does not match the
+  # `Expecting chunk #N` hint (for example a generic `Server out of disk`),
+  # `BazaRb#upload` must re-raise the original `BazaRb::ServerFailure` on the
+  # first PUT instead of entering the rewind loop.
+  def test_upload_raises_on_non_matching_flash_without_rewinding
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'large.txt')
+      File.write(file, 'x' * 2_000_000)
+      received = []
+      stub_request(:put, 'https://example.org:443/file')
+        .to_return do |request|
+          received << request.headers['X-Zerocracy-Chunk']
+          {
+            status: 400,
+            headers: { 'X-Zerocracy-Flash' => 'Server out of disk' }
+          }
+        end
+      baza = BazaRb.new(
+        'example.org', 443, '000',
+        loog: Loog::NULL, compress: false, retries: 2, pause: 0
+      )
+      error =
+        assert_raises(BazaRb::ServerFailure) do
+          baza.send(:upload, baza.send(:home).append('file'), file, {}, chunk_size: 1_000_000)
+        end
+      assert_match(/Server out of disk/, error.message)
+      assert_equal(
+        %w[0], received,
+        'Expected the client to fail on the first PUT without rewinding ' \
+        'when the X-Zerocracy-Flash header does not carry an "Expecting chunk #N" hint'
+      )
+    end
+  end
+
+  # Covers the `raise if rewinds > @retries` exit of the upload rescue block:
+  # when the server keeps returning a matching `Expecting chunk #N` flash on
+  # every PUT, the rewind loop must terminate after the rewind count exceeds
+  # the `retries:` setting and re-raise the original `BazaRb::ServerFailure`,
+  # so a stuck server does not spin the client forever.
+  def test_upload_raises_when_rewinds_exceed_retries
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'large.txt')
+      File.write(file, 'x' * 2_000_000)
+      received = []
+      stub_request(:put, 'https://example.org:443/file')
+        .to_return do |request|
+          chunk = request.headers['X-Zerocracy-Chunk']
+          received << chunk
+          if chunk == '1'
+            {
+              status: 400,
+              headers: {
+                'X-Zerocracy-Flash' => 'Expecting chunk #0 (0b are here), received #1'
+              }
+            }
+          else
+            { status: 200, body: 'OK' }
+          end
+        end
+      retries = 2
+      baza = BazaRb.new(
+        'example.org', 443, '000',
+        loog: Loog::NULL, compress: false, retries: retries, pause: 0
+      )
+      error =
+        assert_raises(BazaRb::ServerFailure) do
+          baza.send(:upload, baza.send(:home).append('file'), file, {}, chunk_size: 1_000_000)
+        end
+      assert_match(/Expecting chunk #0/, error.message)
+      rewinds = received.count('1')
+      assert_equal(
+        retries + 1, rewinds,
+        'Expected the rewind loop to stop after rewinds exceeds the retries: setting'
+      )
+    end
+  end
+
   private
 
   def with_sinatra_server

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -519,8 +519,9 @@ class TestBazaRbEdge < Minitest::Test
       )
       baza.send(:upload, baza.send(:home).append('file'), file, {}, chunk_size: 1_000_000)
       assert_equal(
-        %w[0 1 0 1], received,
-        'Expected the client to restart the upload from chunk #0 after the reboot'
+        %w[0 1 0 1 2], received,
+        'Expected the client to restart the upload from chunk #0 after the reboot, ' \
+        'then re-send chunks 0 and 1 plus the empty terminating chunk #2'
       )
     end
   end


### PR DESCRIPTION
@yegor256 — fixes #109.

## Root cause

`BazaRb#upload` writes a file to the API in `chunk_size`-byte slices, sending `X-Zerocracy-Chunk: N` with each PUT. If the server is rebooted in the middle of an upload it loses its partial state and on the next chunk replies:

```
HTTP/1.1 400 Bad Request
X-Zerocracy-Flash: Expecting chunk #0 (0b are here), received #25
```

The current implementation routes that 400 through `BazaRb#checked`, which raises `BazaRb::ServerFailure`, which is *not* caught by `retry_it` (only `TimedOut` is), so the exception bubbles all the way up and aborts the whole judges pipeline — exactly the failure pasted in the issue.

## Fix

`BazaRb#upload` now wraps the per-chunk PUT in a `begin … rescue BazaRb::ServerFailure`. When the failure message contains the `Expecting chunk #N` hint, the chunk counter is rewound to `N` and the loop continues. Any other `ServerFailure` shape is re-raised unchanged so we don't paper over real errors. The number of rewinds is bounded by the same `retries` setting as transport-level failures, so a server stuck in a reboot loop still surfaces as a failure rather than spinning forever.

## Test

Added `test_upload_restarts_when_server_loses_chunk_state` in `test/test_baza_edge.rb`. It builds a 2 MB file with `chunk_size: 1_000_000`, stubs the PUT endpoint to return a 400 + `X-Zerocracy-Flash: Expecting chunk #0 (0b are here), received #1` exactly once on the first attempt at chunk `1`, and asserts the recorded chunk sequence is `0, 1, 0, 1, 2` (initial attempt, reboot, restart, terminating empty chunk).

- On `master` it fails with the exact error from the issue: `BazaRb::ServerFailure: Invalid response code #400 at PUT https://example.org:443/file (Flash: Expecting chunk #0 (0b are here), received #1)`.
- On this branch it passes.

## Local checks

- `bundle exec rake test` — 75 tests / 87 assertions / 0 failures. The 7 `Errno::EAFNOSUPPORT` errors all come from `RandomPort` / `with_http_server` cases that want `::1` (IPv6 loopback) and reproduce on `master` because the local sandbox does not expose IPv6; they pass on CI (see `rake (ubuntu-24.04, 3.3)` and `rake (macos-15, 3.3)`).
- `bundle exec rubocop` — clean.
- `bundle exec rake yard` — clean.

## CI

All 10 GitHub Actions checks are green: `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `rake (macos-15, 3.3)`, `rake (ubuntu-24.04, 3.3)`, `reuse`, `typos`, `xcop`, `yamllint`. The external `License Compliance` (FOSSA) status is in the same `error / "1 issues found"` state on `master` and on the most recent merged PR (#271), so the failure is unrelated to this change.