### PR TITLE
#281 drop unused faraday and backtrace runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,7 @@ PATH
   remote: .
   specs:
     baza.rb (0.0.0)
-      backtrace (~> 0.4)
       elapsed (~> 0.2)
-      faraday (~> 2.13)
-      faraday-http-cache (~> 2.5)
-      faraday-multipart (~> 1.1)
-      faraday-retry (~> 2.3)
       iri (~> 0.11)
       loog (~> 0.6)
       retries (~> 0.0)
@@ -69,18 +64,6 @@ GEM
       others (~> 0.1)
       tago (~> 0.1)
       yaml (~> 0.3)
-    faraday (2.14.0)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-http-cache (2.6.1)
-      faraday (>= 0.8)
-    faraday-multipart (1.2.0)
-      multipart-post (~> 2.0)
-    faraday-net_http (3.4.2)
-      net-http (~> 0.5)
-    faraday-retry (2.4.0)
-      faraday (~> 2.0)
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
@@ -108,11 +91,8 @@ GEM
       minitest (>= 5.0, < 7)
       ruby-progressbar
     multi_json (1.19.1)
-    multipart-post (2.4.1)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    net-http (0.9.1)
-      uri (>= 0.11.1)
     nio4r (2.7.5)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)

--- a/baza.rb.gemspec
+++ b/baza.rb.gemspec
@@ -23,12 +23,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files | grep -v -E '^(test/|\\.|renovate)'`.split($RS)
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'LICENSE.txt']
-  s.add_dependency 'backtrace', '~>0.4'
   s.add_dependency 'elapsed', '~>0.2'
-  s.add_dependency 'faraday', '~>2.13'
-  s.add_dependency 'faraday-http-cache', '~>2.5'
-  s.add_dependency 'faraday-multipart', '~>1.1'
-  s.add_dependency 'faraday-retry', '~>2.3'
   s.add_dependency 'iri', '~>0.11'
   s.add_dependency 'loog', '~>0.6'
   s.add_dependency 'retries', '~>0.0'


### PR DESCRIPTION
The gemspec declared five runtime dependencies that no code under `lib/` requires or references: `faraday`, `faraday-http-cache`, `faraday-multipart`, `faraday-retry`, and `backtrace`. The library does all of its HTTP work through Typhoeus, so the Faraday stack and `backtrace` were dead weight on every install. Issue #281 calls for dropping the five `s.add_dependency` lines and regenerating `Gemfile.lock`.

Installing `baza.rb` no longer pulls the Faraday gems, `faraday-net_http`, `multipart-post`, `net-http`, or `backtrace` as transitive runtime gems. The gemspec now lists only the gems the library actually uses: `elapsed`, `iri`, `loog`, `retries`, `tago`, and `typhoeus`. No source under `lib/` changed because none of the removed gems were referenced there.

Ran `grep -rn 'faraday\|Faraday\|backtrace\|Backtrace' lib/ test/` and got no matches, confirming the gems were unused. Ran `bundle install` to refresh `Gemfile.lock`; the only deletions are the five removed gems and their transitive entries. Ran `bundle exec rake rubocop` which reported no offenses, and `bundle exec rake test`; the same seven errors and one failure appear on master before the change (IPv6 socket and JSON encoding issues from the sandbox), so they are environmental and not caused by this change.

Closes #281