### PR TITLE
#288 reject non-Integer ids in five job-ID methods

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -141,6 +141,7 @@ class BazaRb
   # @raise [ServerFailure] If the job doesn't exist or pull fails
   def pull(id)
     raise 'The ID of the job is nil' if id.nil?
+    raise 'The ID of the job must be an Integer' unless id.is_a?(Integer)
     raise 'The ID of the job must be a positive integer' unless id.positive?
     data = ''
     elapsed(@loog, level: Logger::INFO) do
@@ -160,6 +161,7 @@ class BazaRb
   # @raise [ServerFailure] If the job doesn't exist
   def finished?(id)
     raise 'The ID of the job is nil' if id.nil?
+    raise 'The ID of the job must be an Integer' unless id.is_a?(Integer)
     raise 'The ID of the job must be a positive integer' unless id.positive?
     fin = false
     elapsed(@loog, level: Logger::INFO) do
@@ -177,6 +179,7 @@ class BazaRb
   # @raise [ServerFailure] If the job doesn't exist or retrieval fails
   def stdout(id)
     raise 'The ID of the job is nil' if id.nil?
+    raise 'The ID of the job must be an Integer' unless id.is_a?(Integer)
     raise 'The ID of the job must be a positive integer' unless id.positive?
     stdout = ''
     elapsed(@loog, level: Logger::INFO) do
@@ -194,6 +197,7 @@ class BazaRb
   # @raise [ServerFailure] If the job doesn't exist or retrieval fails
   def exit_code(id)
     raise 'The ID of the job is nil' if id.nil?
+    raise 'The ID of the job must be an Integer' unless id.is_a?(Integer)
     raise 'The ID of the job must be a positive integer' unless id.positive?
     code = 0
     elapsed(@loog, level: Logger::INFO) do
@@ -211,6 +215,7 @@ class BazaRb
   # @raise [ServerFailure] If the job doesn't exist or retrieval fails
   def verified(id)
     raise 'The ID of the job is nil' if id.nil?
+    raise 'The ID of the job must be an Integer' unless id.is_a?(Integer)
     raise 'The ID of the job must be a positive integer' unless id.positive?
     verdict = ''
     elapsed(@loog, level: Logger::INFO) do

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -452,6 +452,31 @@ class TestBazaRbEdge < Minitest::Test
     assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 
+  def test_pull_raises_when_id_is_not_integer
+    error = assert_raises(RuntimeError) { fake_baza.pull(42.5) }
+    assert_equal('The ID of the job must be an Integer', error.message)
+  end
+
+  def test_finished_raises_when_id_is_not_integer
+    error = assert_raises(RuntimeError) { fake_baza.finished?(42.5) }
+    assert_equal('The ID of the job must be an Integer', error.message)
+  end
+
+  def test_stdout_raises_when_id_is_not_integer
+    error = assert_raises(RuntimeError) { fake_baza.stdout(42.5) }
+    assert_equal('The ID of the job must be an Integer', error.message)
+  end
+
+  def test_exit_code_raises_when_id_is_not_integer
+    error = assert_raises(RuntimeError) { fake_baza.exit_code(42.5) }
+    assert_equal('The ID of the job must be an Integer', error.message)
+  end
+
+  def test_verified_raises_when_id_is_not_integer
+    error = assert_raises(RuntimeError) { fake_baza.verified(42.5) }
+    assert_equal('The ID of the job must be an Integer', error.message)
+  end
+
   def test_upload_switches_host_mid_chunks
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
The five job-ID methods `pull`, `finished?`, `stdout`, `exit_code`, and `verified` in `lib/baza-rb.rb` validate `id` with only `id.nil?` and `id.positive?`. The four durable-ID methods (`durable_save`, `durable_load`, `durable_lock`, `durable_unlock`) additionally require `id.is_a?(Integer)`. Both groups document the parameter as `[Integer] id` and feed it into the same `home.append(...)` URL builder, so the type contract is identical, but a `Float` such as `42.5` passes the job-side guard (`42.5.positive?` is `true`) and gets interpolated into the path as `pull/42.5.fb`, producing a request the server has no route for. `BazaRb::Fake#assert_id` enforces `is_a?(Integer)` for both groups uniformly, so the real client was the laxer of the two and the Fake would not catch this miscall in tests.

The change adds one line, `raise 'The ID of the job must be an Integer' unless id.is_a?(Integer)`, between the existing nil-guard and the positive-guard on each of the five methods, matching the three-line pattern the durable-ID methods already use. No control-flow changes beyond rejecting the previously-accepted `Float` and other non-Integer numeric inputs at the entry point.

Local checks on a clean clone: `bundle exec rake test` runs 79 tests; the 5 new `*_raises_when_id_is_not_integer` cases pass. The 7 `Errno::EAFNOSUPPORT` errors on `::1` come from `RandomPort` / `with_sinatra_server` cases that need IPv6 loopback and reproduce on master in the same sandbox (CI exposes IPv6 and they pass there). The single `test_durable_load_in_chunks` failure is a pre-existing UTF-8/US-ASCII encoding mismatch on master, also reproduced before this branch was created. `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` is clean. `bundle exec yardoc --fail-on-warning lib/**/*.rb` is clean.

Closes #288