### PR TITLE
#289 retry on download timeout by moving checked() inside retry_it

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -800,37 +800,39 @@ class BazaRb
     elapsed(@loog, level: Logger::INFO) do
       loop do
         slice = ''
-        ret = nil
-        retry_if_server_busy do
-          retry_if_server_failed do
-            slice = ''
-            request = Typhoeus::Request.new(
-              uri.to_s,
-              method: :get,
-              headers: headers.merge(
-                'Accept' => '*',
-                'Accept-Encoding' => 'gzip',
-                'Range' => "bytes=#{File.size(file)}-"
-              ),
-              connecttimeout: @timeout,
-              timeout: @timeout
+        ret =
+          retry_it do
+            checked(
+              retry_if_server_failed do
+                retry_if_server_busy do
+                  slice = ''
+                  request = Typhoeus::Request.new(
+                    uri.to_s,
+                    method: :get,
+                    headers: headers.merge(
+                      'Accept' => '*',
+                      'Accept-Encoding' => 'gzip',
+                      'Range' => "bytes=#{File.size(file)}-"
+                    ),
+                    connecttimeout: @timeout,
+                    timeout: @timeout
+                  )
+                  request.on_body do |data|
+                    slice += data
+                  end
+                  request.run
+                  request.response
+                end
+              end,
+              [200, 206, 204, 302]
             )
-            request.on_body do |data|
-              slice += data
-            end
-            retry_it do
-              request.run
-            end
-            ret = request.response
           end
-        end
         msg = [
           "GET #{uri.to_uri.path} #{ret.code}",
           "#{slice.bytesize} bytes",
           ('in gzip' if ret.headers['Content-Encoding'] == 'gzip'),
           ("ranged as #{ret.headers['Content-Range'].inspect}" if ret.headers['Content-Range'])
         ]
-        ret = checked(ret, [200, 206, 204, 302])
         uri = stick_host(ret, uri)
         if blanks.include?(ret.code)
           sleep(2)

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -278,6 +278,28 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  # Reproduces zerocracy/baza.rb#289: BazaRb#download never retries on
+  # timeout because checked() is called outside retry_it. After the fix,
+  # a libcurl operation_timedout on the first GET re-raises BazaRb::TimedOut
+  # from inside retry_it, which retries up to @retries times.
+  def test_download_retries_on_timeout
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'download.txt')
+      stub_request(:get, 'https://example.org:443/file')
+        .with(headers: { 'Range' => 'bytes=0-' })
+        .to_timeout.then
+        .to_return(status: 200, body: 'success content', headers: {})
+      baza = BazaRb.new(
+        'example.org', 443, '000',
+        loog: Loog::NULL, compress: false, timeout: 0.1, retries: 2, pause: 0
+      )
+      baza.send(:download, baza.send(:home).append('file'), file)
+      assert_equal('success content', File.read(file))
+      assert_requested(:get, 'https://example.org:443/file', times: 2)
+    end
+  end
+
   def test_upload_retries_on_busy_server
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
BazaRb#download wraps Typhoeus::Request#run in retry_it but calls checked() after every retry block, so a libcurl operation_timedout return code surfaces from checked() outside the retry wrapper. Since Typhoeus#run does not raise on transport-level failures, the existing retry_it was dead code and the first TimedOut reached the caller on attempt one even with @retries set high.

The fix mirrors the nesting BazaRb#upload uses: wrap checked() in retry_it and keep retry_if_server_failed / retry_if_server_busy underneath. A libcurl operation_timedout now re-raises BazaRb::TimedOut from inside retry_it and triggers the @retries-bounded retry. The on_body slice buffer is reset inside the innermost block so retries do not accumulate response chunks across attempts.

Ran `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n /test_download/` on Ruby 3.3.6: 4 tests, 7 assertions, 0 failures, 0 errors. The full test_baza_edge.rb run shows the 1 pre-existing failure (test_durable_load_in_chunks encoding) and 7 pre-existing errors (network-isolated sinatra and tcp-server tests) that also fail on origin/master in this sandbox, and no new failures introduced by this change.

Closes #289