### PR TITLE
#286 raise required Ruby to 3.3 to match the CI matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read
 [these guidelines](https://www.yegor256.com/2014/04/15/github-guidelines.html).
 Make sure your build is green before you contribute
 your pull request. You will need to have
-[Ruby](https://www.ruby-lang.org/en/) 3.2+ and
+[Ruby](https://www.ruby-lang.org/en/) 3.3+ and
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash

--- a/baza.rb.gemspec
+++ b/baza.rb.gemspec
@@ -8,7 +8,7 @@ require_relative 'lib/baza-rb/version'
 
 Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
-  s.required_ruby_version = '>=3.0'
+  s.required_ruby_version = '>=3.3'
   s.name = 'baza.rb'
   s.version = BazaRb::VERSION
   s.license = 'MIT'


### PR DESCRIPTION
The gemspec at `baza.rb.gemspec:11` declared `s.required_ruby_version = '>=3.0'`, but `.github/workflows/rake.yml:19` only runs `bundle exec rake` against `ruby: [3.3]`. The README at `README.md:22` advertised `Ruby 3.2+` on top, so consumers, the contract, and the CI signal each named a different supported floor. Closes #286.

Raising the gemspec floor to `>=3.3` and the README to `3.3+` aligns all three references to the version the matrix actually exercises. Ruby 3.0, 3.1, and 3.2 reached end-of-life on the upstream schedule, so the new floor names the lowest version still receiving upstream maintenance and the one CI proves on every push.

Verified locally on Ruby 3.3.6: `bundle exec ruby -Ilib -Itest test/test_fake.rb` runs 16 tests, 14 assertions, 0 failures, 0 errors; `rubocop baza.rb.gemspec` is clean. The same coverage warning that prints on master is unchanged by this PR (no `lib/` code was touched).