### PR TITLE
#287 drop unused BazaRb::BadResponse exception class

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -49,9 +49,6 @@ class BazaRb
   # {#retry_it} retries it as a transient failure.
   class ConnectionFailed < TimedOut; end
 
-  # Unexpected response arrived from the server.
-  class BadResponse < StandardError; end
-
   # When the server sent incorrectly compressed data.
   class BadCompression < StandardError; end
 


### PR DESCRIPTION
Issue #287 reports that `BazaRb::BadResponse` is declared at `lib/baza-rb.rb:53` next to `ServerFailure`, `TimedOut`, `ConnectionFailed`, and `BadCompression`, but unlike its four siblings the class is never raised, never rescued, and never referenced anywhere else in the gem. A repo-wide `grep -rn 'BadResponse' lib/ test/` returns only the declaration line, confirming the public exception cannot fire from any code path inside this gem and any consumer writing `rescue BazaRb::BadResponse` is writing an unreachable clause.

The single hunk drops the comment and the class declaration on lines 52-53, leaving the four reachable exceptions in place. No other source file changes, no tests change, and no docs reference `BadResponse`, so the public surface narrows by exactly one symbol with no follow-on edits required. If a future check inside `checked` needs the same name, the class can be reintroduced together with the `raise` site and a test that exercises it.

Local checks on a clean clone: `bundle exec rake rubocop` reports 12 files inspected, no offenses; `bundle exec rake yard` reports 6 classes, 45 methods, 98.11% documented, no warnings; `bundle exec ruby -Ilib -e \"require 'baza-rb'; require 'baza-rb/fake'\"` loads the library cleanly and confirms `BazaRb::ServerFailure`, `TimedOut`, `ConnectionFailed`, and `BadCompression` still resolve while `BazaRb::BadResponse` is gone; `bundle exec rake test` shows the same seven errors and one failure on master before this branch (the `Errno::EAFNOSUPPORT` IPv6 cases under `with_sinatra_server` and the pre-existing UTF-8/US-ASCII encoding case in `test_durable_load_in_chunks`), so they are environmental rather than regressions from this diff.

Closes #287