### PR TITLE
#293 retry POST on 429 like GET and upload PUT

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -773,13 +773,15 @@ class BazaRb
     retry_it do
       checked(
         retry_if_server_failed do
-          Typhoeus::Request.post(
-            uri.to_s,
-            body: params.merge('_csrf' => csrf).sort.to_h,
-            headers:,
-            connecttimeout: @timeout,
-            timeout: @timeout
-          )
+          retry_if_server_busy do
+            Typhoeus::Request.post(
+              uri.to_s,
+              body: params.merge('_csrf' => csrf).sort.to_h,
+              headers:,
+              connecttimeout: @timeout,
+              timeout: @timeout
+            )
+          end
         end,
         allowed
       )

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -299,6 +299,24 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_post_retries_on_busy_server
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://example.org:443/csrf').to_return(body: 'token')
+    attempts = 0
+    stub_request(:post, 'https://example.org:443/lock/simple')
+      .to_return do |_request|
+        attempts += 1
+        if attempts < 2
+          { status: 429, body: 'Too Many Requests' }
+        else
+          { status: 302, body: '' }
+        end
+      end
+    baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, timeout: 0.1, pause: 0)
+    baza.lock('simple', 'owner')
+    assert_equal(2, attempts, 'Expected 2 HTTP calls due to 429 retries on POST')
+  end
+
   # Reproduces zerocracy/baza.rb#122: when an upstream proxy aborts an in-flight
   # request (e.g. nginx returns 499 "Client Closed Request" after a load-balancer
   # timeout), the failure is server-side from the client's point of view and


### PR DESCRIPTION
Closes #293.

`BazaRb#post` at `lib/baza-rb.rb:772-787` wraps `Typhoeus::Request.post` in `retry_if_server_failed` only, while `BazaRb#get` at `:747-763` and the PUT inside `BazaRb#upload` at `:875-931` wrap their requests in `retry_if_server_busy` too. A `429 Too Many Requests` on any POST therefore bypasses the exponential backoff that GET and upload PUT receive and surfaces a `BazaRb::ServerFailure` on the first occurrence. The fix wraps the POST in the same `retry_if_server_busy` block, mirroring the nesting `get` uses, so every POST-driven write — `lock`, `unlock`, `durable_place`, `durable_lock`, `durable_unlock`, `transfer`, `fee`, `enter` — retries on 429 instead of failing immediately under load.

`lock`, `unlock`, `durable_place`, `durable_lock`, `durable_unlock`, `transfer`, `fee`, and the valve POST inside `enter` now retry on 429 with the same `@retries` × `@pause` × 2^attempt backoff that GET and upload PUT use, with no behavior change on any other status code (the two `*_busy` paths are otherwise identical, distinguished only by `>= 499` vs `== 429`).

Verified with `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n test_post_retries_on_busy_server` (1 test, 1 assertion, 0 failures, 0 errors) — the new test stubs a 429 on the first POST and a 302 on the second and asserts two HTTP calls land, exactly the shape of the existing `test_download_retries_on_busy_server` and `test_upload_retries_on_busy_server`. The same test errors against `master` (0 assertions, 1 error: `ServerFailure` on first 429), confirming the fix is what makes the assertion land. `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` is clean. The full edge suite carries a few pre-existing IPv6/`random-port` errors and a UTF-8 encoding diff in `test_durable_load_in_chunks` that reproduce on `master` and are unrelated to this change.
