### PR TITLE
#290 align BazaRb::Fake#durable_load guard with real client

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -157,10 +157,10 @@ class BazaRb::Fake
   # Load a single durable from server to local file.
   #
   # @param [Integer] id The ID of the durable
-  # @param [String] file The file to upload
+  # @param [String] file The local file path to save the downloaded durable
   def durable_load(id, file)
     assert_id(id)
-    assert_file(file)
+    raise 'The "file" of the durable is nil' if file.nil?
   end
 
   # Lock a single durable.

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -88,6 +88,20 @@ class TestFake < Minitest::Test
     end
   end
 
+  def test_durable_load_accepts_nonexistent_target_path
+    baza = BazaRb::Fake.new
+    Dir.mktmpdir do |tmp|
+      target = File.join(tmp, 'not-yet-written.bin')
+      refute_path_exists(target)
+      baza.durable_load(42, target)
+    end
+  end
+
+  def test_durable_load_raises_when_file_is_nil
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.durable_load(42, nil) }
+    assert_equal('The "file" of the durable is nil', error.message)
+  end
+
   def test_transfer
     baza = BazaRb::Fake.new
     receipt_id = baza.transfer('recipient', 1.0, 'test-payment')


### PR DESCRIPTION
Closes #290.

`BazaRb::Fake#durable_load` at `lib/baza-rb/fake.rb:161-164` called `assert_file(file)`, which raises unless `File.exist?(file)` and `File.size(file).positive?`. The real `BazaRb#durable_load` at `lib/baza-rb.rb:356-365` enforces only `file.nil?` and creates or overwrites the target path through `download()` (`FileUtils.rm_f` + `FileUtils.touch` before the write), so the Fake imposed a strict invariant the real client does not. A caller writing `baza.durable_load(42, '/tmp/out.bin')` against the real client passed; the same call against the Fake raised `RuntimeError: The file must exist`.

The fix replaces `assert_file(file)` in `BazaRb::Fake#durable_load` with `raise 'The "file" of the durable is nil' if file.nil?` to mirror the real method, and aligns the YARD comment for `file` with the real client's wording. Two regression tests land in `test/test_fake.rb` next to `test_durable_operations`: `test_durable_load_accepts_nonexistent_target_path` calls `BazaRb::Fake#durable_load` with a `tmp/not-yet-written.bin` path that does not exist and asserts the call succeeds; `test_durable_load_raises_when_file_is_nil` calls it with `nil` and asserts the same `RuntimeError: The "file" of the durable is nil` the real client at `lib/baza-rb.rb:359` raises.

Local checks: `bundle exec ruby -Ilib -Itest test/test_fake.rb` (18 tests, 17 assertions, 0 failures, 0 errors, 0 skips); the new tests fail on `master` and pass on this branch. `bundle exec rubocop lib/baza-rb/fake.rb test/test_fake.rb` is clean.