### PR TITLE
#295 reject non-positive amounts in transfer and fee

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -439,6 +439,7 @@ class BazaRb
     raise 'The "recipient" is nil' if recipient.nil?
     raise 'The "amount" is nil' if amount.nil?
     raise 'The "amount" must be Float' unless amount.is_a?(Float)
+    raise 'The "amount" must be positive' unless amount.positive?
     raise 'The "summary" is nil' if summary.nil?
     id = nil
     body = {
@@ -470,6 +471,7 @@ class BazaRb
     raise 'The "tab" is nil' if tab.nil?
     raise 'The "amount" is nil' if amount.nil?
     raise 'The "amount" must be Float' unless amount.is_a?(Float)
+    raise 'The "amount" must be positive' unless amount.positive?
     raise 'The "job" is nil' if job.nil?
     raise 'The "job" must be Integer' unless job.is_a?(Integer)
     raise 'The "summary" is nil' if summary.nil?

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -452,6 +452,20 @@ class TestBazaRbEdge < Minitest::Test
     assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 
+  def test_transfer_raises_when_amount_is_not_positive
+    [0.0, -1.0, -0.000001].each do |amount|
+      error = assert_raises(RuntimeError) { fake_baza.transfer('jeff', amount, 'pay') }
+      assert_equal('The "amount" must be positive', error.message)
+    end
+  end
+
+  def test_fee_raises_when_amount_is_not_positive
+    [0.0, -1.0, -0.000001].each do |amount|
+      error = assert_raises(RuntimeError) { fake_baza.fee('unknown', amount, 'pay', 42) }
+      assert_equal('The "amount" must be positive', error.message)
+    end
+  end
+
   def test_upload_switches_host_mid_chunks
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
Closes #295. `BazaRb#transfer` at `lib/baza-rb.rb:438-460` and `BazaRb#fee` at `lib/baza-rb.rb:469-491` validated `amount.nil?` and `amount.is_a?(Float)` but not the sign, so `0.0` or `-5.0` reached the wire as `amount=-5.000000` and surfaced as a server-side 4xx instead of a local guard. The Fake at `lib/baza-rb/fake.rb:200` and `lib/baza-rb/fake.rb:215` already raises on non-positive amounts, and the Pact contract at `test/test_baza.rb:120` pins `amount` to `/^[0-9]+\.[0-9]+$/`, so the real client was the only laxer side.

This adds `raise 'The "amount" must be positive' unless amount.positive?` to both methods between the existing Float guard and the next check, matching the message style of the surrounding `nil`/`Float` guards. Two regression tests in `test/test_baza_edge.rb` (`test_transfer_raises_when_amount_is_not_positive`, `test_fee_raises_when_amount_is_not_positive`) exercise `0.0`, `-1.0`, and `-0.000001` against both methods.

Locally: `bundle exec rake test` adds the two new tests cleanly (`76 tests, 120 assertions` vs `74 tests, 108 assertions` on master); the single pre-existing failure (`test_durable_load_in_chunks`) and seven pre-existing errors are unchanged by this diff. `bundle exec rake rubocop` reports `12 files inspected, no offenses detected`. `bundle exec rake yard` reports `98.15% documented` with no new warnings.