### PR TITLE
Fix fake durable_find file validation

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -126,11 +126,12 @@ class BazaRb::Fake
   # Find a single durable.
   #
   # @param [String] pname The name of the job on the server
-  # @param [String] file The path to the file to upload
+  # @param [String] file The file name
   # @return [Integer] Always returns 42 as the fake durable ID
   def durable_find(pname, file)
     assert_name(pname)
-    assert_file(file)
+    raise 'The "file" is nil' if file.nil?
+    raise 'The "file" may not be empty' if file.empty?
     42
   end
 

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -88,6 +88,16 @@ class TestFake < Minitest::Test
     end
   end
 
+  def test_durable_find_accepts_file_name
+    baza = BazaRb::Fake.new
+    assert_equal(42, baza.durable_find('test-job', 'missing.txt'))
+  end
+
+  def test_durable_find_rejects_empty_file_name
+    baza = BazaRb::Fake.new
+    assert_raises(StandardError) { baza.durable_find('test-job', '') }
+  end
+
   def test_transfer
     baza = BazaRb::Fake.new
     receipt_id = baza.transfer('recipient', 1.0, 'test-payment')


### PR DESCRIPTION
Closes #299.

This aligns BazaRb::Fake#durable_find with the real client contract: the argument is a durable file name, not a local file path to upload.

Changes:
- stop requiring the file name to exist on disk for Fake#durable_find
- keep nil/empty validation consistent with BazaRb#durable_find
- update the Fake YARD param text
- add regression coverage for a missing local file name

Validation:
- git diff --check
- GitHub Actions: all checks passed, including rake on ubuntu-24.04 and macos-15 with Ruby 3.3.