### PR TITLE
#302 anchor Content-Range guard regexes with \A and \z

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -852,9 +852,9 @@ class BazaRb
         break if ret.code == 200
         _, v = ret.headers['Content-Range'].split
         range, total = v.split('/')
-        raise "Total size is not valid (#{total.inspect})" unless total.match?(/^\*|[0-9]+$/)
+        raise "Total size is not valid (#{total.inspect})" unless total.match?(/\A(?:\*|[0-9]+)\z/)
         _b, e = range.split('-')
-        raise "Range is not valid (#{range.inspect})" unless e.match?(/^[0-9]+$/)
+        raise "Range is not valid (#{range.inspect})" unless e.match?(/\A[0-9]+\z/)
         len = ret.headers['Content-Length'].to_i
         break if e.to_i == total.to_i - 1
         break if total == '0'

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -452,6 +452,29 @@ class TestBazaRbEdge < Minitest::Test
     assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 
+  def test_download_rejects_malformed_content_range_total
+    WebMock.disable_net_connect!
+    ['*malformed', 'abc123', '0xff', '-5'].each do |total|
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, 'out.bin')
+        host = 'example.org'
+        stub_request(:get, "https://#{host}:443/file")
+          .with(headers: { 'Range' => 'bytes=0-' })
+          .to_return(
+            status: 206,
+            body: 'first ',
+            headers: { 'Content-Range' => "bytes 0-5/#{total}" }
+          )
+        baza = BazaRb.new(host, 443, '000', loog: Loog::NULL, compress: false)
+        error =
+          assert_raises(RuntimeError) do
+            baza.send(:download, baza.send(:home).append('file'), file)
+          end
+        assert_equal("Total size is not valid (#{total.inspect})", error.message)
+      end
+    end
+  end
+
   def test_upload_switches_host_mid_chunks
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
The total-size guard at `lib/baza-rb.rb:855` read `/^\*|[0-9]+$/`, which because of regex precedence parsed as `(^\*)|([0-9]+$)` and matched every string starting with `*` or ending in digits. Values like `*malformed`, `abc123`, and `-5` slipped past the guard, and the downstream `total.to_i` and `e.to_i == total.to_i - 1` comparisons then either spun the chunked-download loop or terminated it on a truncated file. The neighboring range guard at `:857` had the same shape with the milder `^` and `$` line anchors, which also accept strings with a stray newline at the boundaries. Closes #302.

The fix replaces `/^\*|[0-9]+$/` with `/\A(?:\*|[0-9]+)\z/` on `:855` and `/^[0-9]+$/` with `/\A[0-9]+\z/` on `:857`, so the alternation lives under one pair of string anchors and a malformed total or end value raises the existing `"Total size is not valid"` / `"Range is not valid"` errors as the guard intended. `bytes 0-0/*` and `bytes 0-11/25` still match, so the existing `test_durable_load_in_chunks` and `test_download_switches_host_mid_range` paths are unchanged.

A regression test `test_download_rejects_malformed_content_range_total` in `test/test_baza_edge.rb` exercises `*malformed`, `abc123`, `0xff`, and `-5` against the download loop and pins the `RuntimeError` with the exact `"Total size is not valid (...)"` message. `bundle exec rake test` runs the new test green; the pre-existing single failure (`test_durable_load_in_chunks`) and seven pre-existing errors (the `sinatra`/real-HTTP harness) are unchanged by this diff. `bundle exec rake rubocop` reports `12 files inspected, no offenses detected`.

Closes #302