### PR TITLE
Add input guards to enter

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -504,6 +504,14 @@ class BazaRb
   # @return [String] The cached result or newly computed result from the block
   # @raise [ServerFailure] If the valve operation fails
   def enter(pname, badge, why, job)
+    raise 'The "pname" is nil' if pname.nil?
+    raise 'The "pname" may not be empty' if pname.empty?
+    raise 'The "badge" is nil' if badge.nil?
+    raise 'The "badge" may not be empty' if badge.empty?
+    raise 'The "why" is nil' if why.nil?
+    raise 'The "why" may not be empty' if why.empty?
+    raise 'The "job" must be Integer' unless job.nil? || job.is_a?(Integer)
+    raise 'The "job" must be a positive integer' unless job.nil? || job.positive?
     elapsed(@loog, good: "Entered valve #{badge} to #{pname}") do
       retry_it do
         ret = get(home.append('result').add(badge:), [200, 204])

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -452,6 +452,38 @@ class TestBazaRbEdge < Minitest::Test
     assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 
+  def test_enter_raises_when_pname_is_nil
+    assert_enter_rejects(nil, 'badge', 'why', nil, 'The "pname" is nil')
+  end
+
+  def test_enter_raises_when_pname_is_empty
+    assert_enter_rejects('', 'badge', 'why', nil, 'The "pname" may not be empty')
+  end
+
+  def test_enter_raises_when_badge_is_nil
+    assert_enter_rejects('pname', nil, 'why', nil, 'The "badge" is nil')
+  end
+
+  def test_enter_raises_when_badge_is_empty
+    assert_enter_rejects('pname', '', 'why', nil, 'The "badge" may not be empty')
+  end
+
+  def test_enter_raises_when_why_is_nil
+    assert_enter_rejects('pname', 'badge', nil, nil, 'The "why" is nil')
+  end
+
+  def test_enter_raises_when_why_is_empty
+    assert_enter_rejects('pname', 'badge', '', nil, 'The "why" may not be empty')
+  end
+
+  def test_enter_raises_when_job_is_not_integer
+    assert_enter_rejects('pname', 'badge', 'why', 'job', 'The "job" must be Integer')
+  end
+
+  def test_enter_raises_when_job_is_not_positive
+    assert_enter_rejects('pname', 'badge', 'why', 0, 'The "job" must be a positive integer')
+  end
+
   def test_upload_switches_host_mid_chunks
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|
@@ -486,6 +518,22 @@ class TestBazaRbEdge < Minitest::Test
   end
 
   private
+
+  def assert_enter_rejects(pname, badge, why, job, message)
+    ran = false
+    error =
+      assert_raises(RuntimeError) do
+        fake_baza.enter(pname, badge, why, job) do
+          ran = true
+          'result'
+        end
+      end
+    assert_equal(message, error.message)
+    refute(
+      ran,
+      'Invalid enter arguments must be rejected before the block is executed'
+    )
+  end
 
   def with_sinatra_server
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
Closes #298.

This aligns BazaRb#enter with the validation behavior expected by the fake client and sibling public methods. Invalid arguments now fail before opening the elapsed block, issuing HTTP calls, or executing the caller-provided computation block.

Changes:
- reject nil and empty pname, badge, and why values
- keep job optional, but reject non-Integer and non-positive values when provided
- add edge-case tests for each guard
- assert invalid inputs do not execute the enter block

Validation:
- git diff --check
- GitHub Actions: all checks passed, including rake on ubuntu-24.04 and macos-15 with Ruby 3.3.