### PR TITLE
fix(fake): #309 align lock owner guards with the real client

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -94,7 +94,8 @@ class BazaRb::Fake
   # @param [String] owner The owner of the lock (any string)
   def lock(name, owner)
     assert_name(name)
-    assert_owner(owner)
+    raise 'The "owner" of the lock is nil' if owner.nil?
+    raise 'The "owner" of the lock may not be empty' if owner.empty?
   end
 
   # Unlock the name.
@@ -103,7 +104,8 @@ class BazaRb::Fake
   # @param [String] owner The owner of the lock (any string)
   def unlock(name, owner)
     assert_name(name)
-    assert_owner(owner)
+    raise 'The "owner" of the lock is nil' if owner.nil?
+    raise 'The "owner" of the lock may not be empty' if owner.empty?
   end
 
   # Get the ID of the job by the name.
@@ -171,7 +173,8 @@ class BazaRb::Fake
   # @param [String] owner The owner of the lock
   def durable_lock(id, owner)
     assert_id(id)
-    assert_owner(owner)
+    raise 'The "owner" of the lock is nil' if owner.nil?
+    raise 'The "owner" of the lock may not be empty' if owner.empty?
   end
 
   # Unlock a single durable.
@@ -180,7 +183,8 @@ class BazaRb::Fake
   # @param [String] owner The owner of the lock
   def durable_unlock(id, owner)
     assert_id(id)
-    assert_owner(owner)
+    raise 'The "owner" of the lock is nil' if owner.nil?
+    raise 'The "owner" of the lock may not be empty' if owner.empty?
   end
 
   # Get current balance of the authenticated user.
@@ -254,11 +258,6 @@ class BazaRb::Fake
   def assert_id(id)
     raise 'The ID must be an Integer' unless id.is_a?(Integer)
     raise 'The ID must be positive' unless id.positive?
-  end
-
-  def assert_owner(owner)
-    raise "The owner #{owner.inspect} is not valid" unless owner.match?(/^[a-zA-Z0-9-]+$/)
-    raise "The owner #{owner.inspect} is too long" if owner.length > 64
   end
 
   def assert_file(file)

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -70,6 +70,22 @@ class TestFake < Minitest::Test
     baza.unlock('test-job', 'test-owner')
   end
 
+  def test_lock_accepts_owner_with_spaces
+    baza = BazaRb::Fake.new
+    baza.lock('pact1', 'Jeff Lebowski')
+    baza.unlock('pact1', 'Jeff Lebowski')
+  end
+
+  def test_lock_raises_when_owner_is_nil
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.lock('pact1', nil) }
+    assert_equal('The "owner" of the lock is nil', error.message)
+  end
+
+  def test_lock_raises_when_owner_is_empty
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.lock('pact1', '') }
+    assert_equal('The "owner" of the lock may not be empty', error.message)
+  end
+
   def test_recent
     baza = BazaRb::Fake.new
     id = baza.recent('test-job')
@@ -92,6 +108,22 @@ class TestFake < Minitest::Test
       baza.durable_lock(42, 'test-owner')
       baza.durable_unlock(42, 'test-owner')
     end
+  end
+
+  def test_durable_lock_accepts_owner_with_email_shape
+    baza = BazaRb::Fake.new
+    baza.durable_lock(42, 'jeff@example.com')
+    baza.durable_unlock(42, 'jeff@example.com')
+  end
+
+  def test_durable_lock_raises_when_owner_is_nil
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.durable_lock(42, nil) }
+    assert_equal('The "owner" of the lock is nil', error.message)
+  end
+
+  def test_durable_lock_raises_when_owner_is_empty
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.durable_lock(42, '') }
+    assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 
   def test_durable_save_accepts_chunk_size_kwarg

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -86,6 +86,16 @@ class TestFake < Minitest::Test
     assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 
+  def test_unlock_raises_when_owner_is_nil
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.unlock('pact1', nil) }
+    assert_equal('The "owner" of the lock is nil', error.message)
+  end
+
+  def test_unlock_raises_when_owner_is_empty
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.unlock('pact1', '') }
+    assert_equal('The "owner" of the lock may not be empty', error.message)
+  end
+
   def test_recent
     baza = BazaRb::Fake.new
     id = baza.recent('test-job')
@@ -123,6 +133,16 @@ class TestFake < Minitest::Test
 
   def test_durable_lock_raises_when_owner_is_empty
     error = assert_raises(RuntimeError) { BazaRb::Fake.new.durable_lock(42, '') }
+    assert_equal('The "owner" of the lock may not be empty', error.message)
+  end
+
+  def test_durable_unlock_raises_when_owner_is_nil
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.durable_unlock(42, nil) }
+    assert_equal('The "owner" of the lock is nil', error.message)
+  end
+
+  def test_durable_unlock_raises_when_owner_is_empty
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.durable_unlock(42, '') }
     assert_equal('The "owner" of the lock may not be empty', error.message)
   end
 


### PR DESCRIPTION
Closes #309. `BazaRb::Fake#lock`, `#unlock`, `#durable_lock`, and `#durable_unlock` all called `assert_owner(owner)`, which enforced `/^[a-zA-Z0-9-]+$/` and a 64-character cap. The real `BazaRb#lock`/`#unlock` at `lib/baza-rb.rb:232-244` and `#durable_lock`/`#durable_unlock` at `:376-406` only enforce `nil` and `empty?`, send the owner as a plain `owner` form field, and document the parameter as `The owner of the lock (any string)`. The Pact contract in `test/test_baza.rb:277-309` and `:473` pins the server-side field to `match_regex(/^.+$/, ...)` and uses the fixtures `'Jeff Lebowski'`, `'Barack Obama'`, and `'Donald Trump'`. The Fake was the stricter side, and the drift surfaced only when production code switched from the Fake to the real client.

The four `Fake` methods now run the same two-line guard the real client uses — `raise 'The "owner" of the lock is nil' if owner.nil?` and `raise 'The "owner" of the lock may not be empty' if owner.empty?` — and the unused `assert_owner` helper at `lib/baza-rb/fake.rb:257-260` is removed. No public signature changes, and no other caller of `assert_owner` exists in `lib/` or `test/`.

`bundle exec ruby -Ilib -Itest test/test_fake.rb` reports `26 tests, 26 assertions, 0 failures, 0 errors, 0 skips`, including the new `test_lock_accepts_owner_with_spaces`, `test_lock_raises_when_owner_is_nil`, `test_lock_raises_when_owner_is_empty`, `test_durable_lock_accepts_owner_with_email_shape`, `test_durable_lock_raises_when_owner_is_nil`, and `test_durable_lock_raises_when_owner_is_empty`. `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb` reports `36 tests, 84 assertions, 1 failures, 7 errors, 0 skips` — the pre-existing `test_durable_load_in_chunks` failure and the seven `random-port` errors from the real-HTTP harness are unchanged by this diff, and the existing `test_lock_raises_when_owner_is_empty` continues to pass. `bundle exec rubocop lib/baza-rb/fake.rb test/test_fake.rb` reports `2 files inspected, no offenses detected`.
