### PR TITLE
Handle malformed Content-Range without hyphen

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -861,7 +861,8 @@ class BazaRb
         _, v = ret.headers['Content-Range'].split
         range, total = v.split('/')
         raise "Total size is not valid (#{total.inspect})" unless total.match?(/^\*|[0-9]+$/)
-        _b, e = range.split('-')
+        _b, e = range.split('-', 2)
+        raise "Range is not valid (#{range.inspect})" if e.nil?
         raise "Range is not valid (#{range.inspect})" unless e.match?(/^[0-9]+$/)
         len = ret.headers['Content-Length'].to_i
         break if e.to_i == total.to_i - 1

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -154,6 +154,18 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_durable_load_reports_invalid_content_range_without_hyphen
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'loaded.txt')
+      stub_request(:get, 'https://example.org:443/durables/42')
+        .with(headers: { 'Range' => 'bytes=0-' })
+        .to_return(status: 206, body: 'x', headers: { 'Content-Range' => 'bytes 0/10' })
+      error = assert_raises(RuntimeError) { fake_baza.durable_load(42, file) }
+      assert_includes(error.message, 'Range is not valid ("0")')
+    end
+  end
+
   def test_durable_load_with_broken_compression
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
`BazaRb#download` currently assumes the `range` part of a `Content-Range`
header always contains a hyphen. For a malformed response such as
`Content-Range: bytes 0/10`, `range.split('-')` leaves `e` as `nil`, and the
next line raises `NoMethodError` from `e.match?` instead of the existing
`Range is not valid (...)` validation error.

This keeps the existing validation behavior and adds only a missing-end guard:
split the range into at most two parts, raise `Range is not valid (...)` when
the end part is absent, and then run the existing numeric end check.

I checked for duplicates before opening this:

- `#312` is still open, has no comments, and is labeled `bug`.
- PR searches for `Content-Range range hyphen NoMethodError 312` returned no matching PRs.
- Open PR `#310` is for `#302` and anchors the total/range regexes; it does not handle the missing-hyphen `nil.match?` crash covered here.

Validation run locally on Windows with Ruby 3.3.11:

- New regression test fails before this patch with `NoMethodError: undefined method 'match?' for nil` at `lib/baza-rb.rb:865`.
- `bundle exec ruby -Itest -e "ARGV << '--no-cov'; require_relative 'test/test_baza_edge'; ARGV.delete('--no-cov')" -- --name test_durable_load_reports_invalid_content_range_without_hyphen`
- `bundle exec ruby -Itest -e "ARGV << '--no-cov'; require_relative 'test/test_baza_edge'; ARGV.delete('--no-cov')" -- --name test_durable_load_in_chunks`
- `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb`
- `ruby -c lib\baza-rb.rb`
- `ruby -c test\test_baza_edge.rb`
- `git diff --check`
- `git diff -- lib\baza-rb.rb test\test_baza_edge.rb | gitleaks stdin --no-banner --redact`

Both focused tests pass after the fix, RuboCop reports no offenses, syntax
checks pass, diff whitespace is clean, and gitleaks reports no leaks. I also
attempted the project default `bundle exec rake`; it timed out after 300s on my
local Windows setup, so I am not claiming full-suite completion from this
machine.

Closes #312
