### PR TITLE
#313 raise rubocop target ruby to 3.3 and re-enable required-ruby cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'assets/**/*'
     - 'vendor/**/**'
   DisplayCopNames: true
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
   NewCops: enable
 plugins:
@@ -19,8 +19,6 @@ Minitest/EmptyLineBeforeAssertionMethods:
 Style/GlobalVars:
   Enabled: false
 Lint/NestedMethodDefinition:
-  Enabled: false
-Gemspec/RequiredRubyVersion:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false


### PR DESCRIPTION
Closes #313. `.rubocop.yml` set `AllCops/TargetRubyVersion: 3.2` while `baza.rb.gemspec` declares `required_ruby_version = '>=3.3'`, `README.md` instructs contributors to install Ruby `3.3+`, and `.github/workflows/rake.yml` runs the matrix only on `[3.3]`. The drift was masked by `Gemspec/RequiredRubyVersion: Enabled: false`, which silenced the one cop whose job is to fail the build when the gemspec and the rubocop target disagree.

The change raises `TargetRubyVersion` to `3.3` and drops the `Gemspec/RequiredRubyVersion: Enabled: false` override so the linter pins the version contract going forward. No source files change.

Ran `bundle exec rake rubocop yard` locally with Ruby 3.3.6: rubocop reports `12 files inspected, no offenses detected`, YARD reports `98.11% documented`. Non-live unit tests (everything except `test/test_baza_live.rb`) were also run; the pre-existing `test_durable_load_in_chunks` failure and the seven `random-port` errors from the real-HTTP harness on master are unchanged by this diff.
