### PR TITLE
#316: guard fake push nil data

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -38,6 +38,7 @@ class BazaRb::Fake
   # @return [Integer] Always returns 42 as the fake job ID
   def push(name, data, meta, chunk_size: BazaRb::DEFAULT_CHUNK_SIZE) # rubocop:disable Lint/UnusedMethodArgument
     checkname(name)
+    raise(RuntimeError, 'The "data" of the job is nil') if data.nil?
     raise(RuntimeError, 'The data must be non-empty') if data.empty?
     raise(RuntimeError, 'The meta must be an array') unless meta.is_a?(Array)
     42

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -28,6 +28,13 @@ class TestFake < Minitest::Test
     assert_equal(42, BazaRb::Fake.new.push('test-job', 'test-data', []))
   end
 
+  def test_push_raises_when_data_is_nil
+    assert_equal(
+      'The "data" of the job is nil',
+      assert_raises(RuntimeError) { BazaRb::Fake.new.push('test-job', nil, []) }.message
+    )
+  end
+
   def test_push_accepts_chunk_size_kwarg
     assert_equal(42, BazaRb::Fake.new.push('test-job', 'test-data', [], chunk_size: 1024))
   end


### PR DESCRIPTION
Summary:
- Add the missing nil-data guard to BazaRb::Fake#push before the existing empty-data check.
- Cover the fake client behavior so nil data now raises the same documented RuntimeError message as BazaRb#push.

Closes #316

Validation:
- Reproduced before fix: bundle exec ruby -Ilib -e "require './lib/baza-rb/fake'; begin; BazaRb::Fake.new.push('test-job', nil, []); rescue => e; puts \"#{e.class}: #{e.message}\"; exit(e.is_a?(NoMethodError) ? 0 : 1); end; exit 2" -> NoMethodError: undefined method 'empty?' for nil.
- Post-fix behavior: bundle exec ruby -Ilib -e "require './lib/baza-rb/fake'; begin; BazaRb::Fake.new.push('test-job', nil, []); rescue => e; puts \"#{e.class}: #{e.message}\"; exit(e.is_a?(RuntimeError) && e.message == 'The \"data\" of the job is nil' ? 0 : 1); end; exit 2" -> RuntimeError: The "data" of the job is nil.
- bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/test_fake"; ARGV.delete("--no-cov")' -> 21 tests, 20 assertions, 0 failures, 0 errors, 0 skips.
- bundle exec rubocop lib/baza-rb/fake.rb test/test_fake.rb -> 2 files inspected, no offenses detected.
- git diff --cached --check -> passed.
- gitleaks protect --staged --no-banner --redact --verbose -> no leaks found.

Not run:
- Full rake suite, because test/test_baza_live.rb makes live api.zerocracy.com calls and the current ROE for this issue is local-only.