### PR TITLE
#303: avoid recomputing enter block on retry

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -509,12 +509,12 @@ class BazaRb
   # @raise [ServerFailure] If the valve operation fails
   def enter(pname, badge, why, job)
     elapsed(@loog, good: "Entered valve #{badge} to #{pname}") do
+      ret = retry_it { get(home.append('result').add(badge:), [200, 204]) }
+      return ret.body if ret.code == 200
+      r = yield
+      uri = home.append('valves')
+      uri = uri.add(job:) unless job.nil?
       retry_it do
-        ret = get(home.append('result').add(badge:), [200, 204])
-        return ret.body if ret.code == 200
-        r = yield
-        uri = home.append('valves')
-        uri = uri.add(job:) unless job.nil?
         post(
           uri,
           {
@@ -524,8 +524,8 @@ class BazaRb
             'why' => why
           }
         )
-        r
       end
+      r
     end
   end
 

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -339,6 +339,28 @@ class TestBazaRbEdge < Minitest::Test
     assert_equal(2, attempts, 'Expected 2 HTTP calls due to 429 retries on POST')
   end
 
+  def test_enter_does_not_recompute_when_valve_post_outer_retry_succeeds
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://example.org:443/result')
+      .with(query: { 'badge' => 'bar' })
+      .to_return(status: 204, body: '')
+    stub_request(:get, 'https://example.org:443/csrf').to_return(body: 'token')
+    stub_request(:post, 'https://example.org:443/valves')
+      .to_timeout.then
+      .to_timeout.then
+      .to_return(status: 302)
+    calls = 0
+    baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, retries: 2, pause: 0)
+    result =
+      baza.enter('pact9', 'bar', 'no reason', nil) do
+        calls += 1
+        "after-#{calls}"
+      end
+    assert_equal('after-1', result)
+    assert_equal(1, calls, 'enter must not rerun the user block while retrying valve storage')
+    assert_requested(:post, 'https://example.org:443/valves', times: 3)
+  end
+
   # Reproduces zerocracy/baza.rb#122: when an upstream proxy aborts an in-flight
   # request (e.g. nginx returns 499 "Client Closed Request" after a load-balancer
   # timeout), the failure is server-side from the client's point of view and


### PR DESCRIPTION
﻿Fixes #303.

BazaRb#enter used to wrap result lookup, the user block, and valve persistence in one outer retry. If POST /valves exhausted its own inner timeout retries and then succeeded on the outer retry, the user block ran again for the same logical enter call.

This change keeps the result lookup retryable, computes the missing value once, then retries only valve persistence. The new regression makes two timed-out POST /valves attempts force the outer retry and verifies the call still returns after-1 with the block invoked once.

Validation:
- RED before fix: test_enter_does_not_recompute_when_valve_post_outer_retry_succeeds failed with expected after-1, actual after-2.
- Focused regression: 1 tests, 3 assertions, 0 failures, 0 errors, 0 skips.
- Adjacent focused edge tests: 2 tests, 4 assertions, 0 failures, 0 errors, 0 skips.
- Adjacent Pact enter tests: 2 tests, 2 assertions, 0 failures, 0 errors, 0 skips.
- rubocop lib/baza-rb.rb test/test_baza_edge.rb: no offenses.
- ruby -c lib/baza-rb.rb; ruby -c test/test_baza_edge.rb: syntax OK.
- git diff --check; git diff --cached --check; diff/staged gitleaks: passed.

Not claimed: full test/test_baza_edge.rb is not clean in this Windows environment because unrelated tests hit a temp-file permission error and a missing /bin/bash helper.
