### PR TITLE
#305: anchor Content-Range total guard

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -860,7 +860,7 @@ class BazaRb
         break if ret.code == 200
         _, v = ret.headers['Content-Range'].split
         range, total = v.split('/')
-        raise "Total size is not valid (#{total.inspect})" unless total.match?(/^\*|[0-9]+$/)
+        raise "Total size is not valid (#{total.inspect})" unless total.match?(/\A(?:\*|[0-9]+)\z/)
         _b, e = range.split('-')
         raise "Range is not valid (#{range.inspect})" unless e.match?(/^[0-9]+$/)
         len = ret.headers['Content-Length'].to_i

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -300,6 +300,21 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_download_rejects_malformed_total_size
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'download.txt')
+      stub_request(:get, 'https://example.org:443/file')
+        .with(headers: { 'Range' => 'bytes=0-' })
+        .to_return(status: 206, body: 'x', headers: { 'Content-Range' => 'bytes 0-0/*malformed' })
+      error =
+        assert_raises(RuntimeError) do
+          fake_baza.send(:download, fake_baza.send(:home).append('file'), file)
+        end
+      assert_includes(error.message, 'Total size is not valid ("*malformed")')
+    end
+  end
+
   def test_upload_retries_on_busy_server
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
/claim #305
Fixes #305

Summary:
- anchors the Content-Range total-size validation as `\A(?:\*|[0-9]+)\z`, so malformed totals like `*malformed` and `abc123` no longer pass just because they start with `*` or end with digits
- adds an offline WebMock regression that verifies a malformed ranged response raises `Total size is not valid` before the download loop can advance to the next range request

Validation:
- Docker Ruby 3.3: `bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/test_baza_edge"; ARGV.delete("--no-cov")'` -> 37 tests, 105 assertions, 0 failures\n- Docker Ruby 3.3: `bundle exec rake test -- --offline` -> 91 tests, 145 assertions, 0 failures, 8 skips (live tests skipped via `--offline`)\n- Docker Ruby 3.3: `bundle exec rubocop` -> 12 files inspected, no offenses\n- `git diff --cached --check`\n- `gitleaks protect --staged --no-banner --redact --verbose`\n\nNo secrets, credentials, wallet material, live service calls, or production mutations were used. The broader test run used the repository offline flag to avoid live Zerocracy API calls.