### PR TITLE
#322: align fake transfer signature

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -195,12 +195,17 @@ class BazaRb::Fake
   # @param [String] recipient GitHub username of the recipient
   # @param [Float] amount The amount to transfer in ƶ (zents)
   # @param [String] summary The description/reason for the payment
+  # @param [Integer] job Optional job ID to associate with this transfer
   # @return [Integer] Always returns 42 as the fake receipt ID
-  def transfer(recipient, amount, summary, *)
+  def transfer(recipient, amount, summary, job: nil)
+    raise 'The "recipient" is nil' if recipient.nil?
     raise "The recipient #{recipient.inspect} is not valid" unless recipient.match?(/\A[a-zA-Z0-9-]+\z/)
-    raise "The amount #{amount} must be a Float" unless amount.is_a?(Float)
-    raise "The amount #{amount} must be positive" unless amount.positive?
+    raise 'The "amount" is nil' if amount.nil?
+    raise 'The "amount" must be Float' unless amount.is_a?(Float)
+    raise 'The "amount" must be positive' unless amount.positive?
+    raise 'The "summary" is nil' if summary.nil?
     raise "The summary #{summary.inspect} is empty" if summary.empty?
+    assert_id(job) unless job.nil?
     42
   end
 

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -131,6 +131,50 @@ class TestFake < Minitest::Test
     assert_equal('The recipient "recipient\nbad value" is not valid', err.message)
   end
 
+  def test_transfer_accepts_job_kwarg
+    receipt_id = BazaRb::Fake.new.transfer('recipient', 1.0, 'test-payment', job: 42)
+    assert_equal(42, receipt_id)
+  end
+
+  def test_transfer_rejects_unknown_keyword
+    assert_raises(ArgumentError) do
+      BazaRb::Fake.new.transfer('recipient', 1.0, 'test-payment', other: 42)
+    end
+  end
+
+  def test_transfer_rejects_invalid_job
+    error =
+      assert_raises(RuntimeError) do
+        BazaRb::Fake.new.transfer('recipient', 1.0, 'test-payment', job: '42')
+      end
+    assert_equal('The ID must be an Integer', error.message)
+  end
+
+  def test_transfer_rejects_nil_recipient
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.transfer(nil, 1.0, 'test-payment') }
+    assert_equal('The "recipient" is nil', error.message)
+  end
+
+  def test_transfer_rejects_nil_amount
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.transfer('recipient', nil, 'test-payment') }
+    assert_equal('The "amount" is nil', error.message)
+  end
+
+  def test_transfer_rejects_non_float_amount
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.transfer('recipient', 1, 'test-payment') }
+    assert_equal('The "amount" must be Float', error.message)
+  end
+
+  def test_transfer_rejects_negative_amount
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.transfer('recipient', -1.0, 'test-payment') }
+    assert_equal('The "amount" must be positive', error.message)
+  end
+
+  def test_transfer_rejects_nil_summary
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.transfer('recipient', 1.0, nil) }
+    assert_equal('The "summary" is nil', error.message)
+  end
+
   def test_pays_fee
     baza = BazaRb::Fake.new
     receipt_id = baza.fee('unknown', 43.0, 'for fun', 44)


### PR DESCRIPTION
Closes #322.

This aligns `BazaRb::Fake#transfer` with `BazaRb#transfer` for the reported fake/real drift:

- changes the fake transfer signature from a trailing splat to `job: nil`
- validates a provided fake `job:` with the existing fake ID guard instead of swallowing it silently
- matches the real transfer nil/type/positive guard wording for recipient, amount, and summary
- adds focused fake-client regression coverage for the new signature and guards

Validation:

- `bundle exec ruby -Itest test/test_fake.rb -- --no-cov` -> 28 tests, 32 assertions, 0 failures, 0 errors
- `bundle exec rake test -- --offline --no-cov` -> 98 tests, 156 assertions, 0 failures, 0 errors, 8 skips; live tests skipped by offline mode, no production calls
- `bundle exec rubocop lib/baza-rb/fake.rb test/test_fake.rb` -> no offenses
- `bundle exec rake rubocop` -> 12 files inspected, no offenses
- `bundle exec rake picks` -> passed
- `bundle exec rake yard` -> passed, 98.11% documented
- `git diff --check upstream/master...HEAD` -> passed
- `git diff --no-ext-diff upstream/master...HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found
