### PR TITLE
#325: align fake fee amount guards

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -213,8 +213,9 @@ class BazaRb::Fake
   # @return [Integer] Always returns 42 as the fake receipt ID
   def fee(tab, amount, summary, job)
     raise 'The "tab" is nil' if tab.nil?
-    raise "The amount #{amount} must be a Float" unless amount.is_a?(Float)
-    raise "The amount #{amount} must be positive" unless amount.positive?
+    raise 'The "amount" is nil' if amount.nil?
+    raise 'The "amount" must be Float' unless amount.is_a?(Float)
+    raise 'The "amount" must be positive' unless amount.positive?
     raise 'The "job" is nil' if job.nil?
     raise 'The "job" must be Integer' unless job.is_a?(Integer)
     raise 'The "summary" is nil' if summary.nil?

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -129,6 +129,21 @@ class TestFake < Minitest::Test
     assert_equal(42, receipt_id)
   end
 
+  def test_fee_raises_when_amount_is_nil
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.fee('unknown', nil, 'for fun', 44) }
+    assert_equal('The "amount" is nil', error.message)
+  end
+
+  def test_fee_raises_when_amount_is_not_float
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.fee('unknown', 43, 'for fun', 44) }
+    assert_equal('The "amount" must be Float', error.message)
+  end
+
+  def test_fee_raises_when_amount_is_not_positive
+    error = assert_raises(RuntimeError) { BazaRb::Fake.new.fee('unknown', 0.0, 'for fun', 44) }
+    assert_equal('The "amount" must be positive', error.message)
+  end
+
   def test_enter
     baza = BazaRb::Fake.new
     result =


### PR DESCRIPTION
Fixes #325.

BazaRb::Fake#fee now follows the real BazaRb#fee amount guard order and wording: nil amounts raise `The "amount" is nil`, non-Float values raise `The "amount" must be Float`, and non-positive Float values raise `The "amount" must be positive`. This removes the prior nil fallthrough into `nil.is_a?(Float)` and keeps fake-client tests aligned with the production client contract.

Validation:
- `bundle exec ruby -Itest test/test_fake.rb -- --no-cov` -> 23 tests, 24 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec rake test -- --offline --no-cov` -> 94 tests, 151 assertions, 0 failures, 0 errors, 8 skips.
- `bundle exec rubocop lib/baza-rb/fake.rb test/test_fake.rb --format simple` -> 2 files inspected, no offenses.
- `ruby -c lib/baza-rb/fake.rb` and `ruby -c test/test_fake.rb` -> Syntax OK.
- `git diff --check` -> passed.
- `git diff -- lib/baza-rb/fake.rb test/test_fake.rb | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Collision check immediately before push: issue #325 was open/unassigned with no linked closing PR, and open PR searches for `325` and `fee` both returned no results.