### PR TITLE
#327: reject multiline fake validators

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -197,7 +197,7 @@ class BazaRb::Fake
   # @param [String] summary The description/reason for the payment
   # @return [Integer] Always returns 42 as the fake receipt ID
   def transfer(recipient, amount, summary, *)
-    raise "The recipient #{recipient.inspect} is not valid" unless recipient.match?(/^[a-zA-Z0-9-]+$/)
+    raise "The recipient #{recipient.inspect} is not valid" unless recipient.match?(/\A[a-zA-Z0-9-]+\z/)
     raise "The amount #{amount} must be a Float" unless amount.is_a?(Float)
     raise "The amount #{amount} must be positive" unless amount.positive?
     raise "The summary #{summary.inspect} is empty" if summary.empty?
@@ -231,7 +231,7 @@ class BazaRb::Fake
   # @return [String] Always executes and returns the block's result
   def enter(name, badge, why, job)
     assert_name(name)
-    raise "The badge '#{badge}' is not valid" unless badge.match?(/^[a-zA-Z0-9_-]+$/)
+    raise "The badge '#{badge}' is not valid" unless badge.match?(/\A[a-zA-Z0-9_-]+\z/)
     raise 'The reason cannot be empty' if why.empty?
     assert_id(job) unless job.nil?
     yield
@@ -247,7 +247,7 @@ class BazaRb::Fake
   private
 
   def assert_name(name)
-    raise "The name #{name.inspect} is not valid" unless name.match?(/^[a-z0-9-]+$/)
+    raise "The name #{name.inspect} is not valid" unless name.match?(/\A[a-z0-9-]+\z/)
     raise "The name #{name.inspect} is too long" if name.length > 32
   end
 
@@ -257,7 +257,7 @@ class BazaRb::Fake
   end
 
   def assert_owner(owner)
-    raise "The owner #{owner.inspect} is not valid" unless owner.match?(/^[a-zA-Z0-9-]+$/)
+    raise "The owner #{owner.inspect} is not valid" unless owner.match?(/\A[a-zA-Z0-9-]+\z/)
     raise "The owner #{owner.inspect} is too long" if owner.length > 64
   end
 

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -123,6 +123,14 @@ class TestFake < Minitest::Test
     assert_equal(42, receipt_id)
   end
 
+  def test_transfer_rejects_multiline_recipient
+    err =
+      assert_raises(RuntimeError) do
+        BazaRb::Fake.new.transfer("recipient\nbad value", 1.0, 'test-payment')
+      end
+    assert_equal('The recipient "recipient\nbad value" is not valid', err.message)
+  end
+
   def test_pays_fee
     baza = BazaRb::Fake.new
     receipt_id = baza.fee('unknown', 43.0, 'for fun', 44)
@@ -136,6 +144,28 @@ class TestFake < Minitest::Test
         'test-result'
       end
     assert_equal('test-result', result)
+  end
+
+  def test_enter_rejects_multiline_name_and_badge
+    baza = BazaRb::Fake.new
+    name =
+      assert_raises(RuntimeError) do
+        baza.enter("test-job\nBAD", 'test-badge', 'test-reason', 42) { 'ignored' }
+      end
+    badge =
+      assert_raises(RuntimeError) do
+        baza.enter('test-job', "test-badge\nBAD", 'test-reason', 42) { 'ignored' }
+      end
+    assert_equal('The name "test-job\nBAD" is not valid', name.message)
+    assert_equal("The badge 'test-badge\nBAD' is not valid", badge.message)
+  end
+
+  def test_durable_lock_rejects_multiline_owner
+    err =
+      assert_raises(RuntimeError) do
+        BazaRb::Fake.new.durable_lock(42, "test-owner\nbad value")
+      end
+    assert_equal('The owner "test-owner\nbad value" is not valid', err.message)
   end
 
   def test_csrf


### PR DESCRIPTION
Fixes #327.

Summary:
- Replaces line anchors with string anchors in the Fake validators for transfer recipients, valve badges, names, and durable-lock owners.
- Adds regression coverage for multiline recipient, name, badge, and owner values so the Fake rejects payloads the real API should reject.

Validation:
- `env BUNDLE_PATH=/private/tmp/bundle-baza-327 mise x ruby@3.3.11 -- bundle exec ruby -Itest test/test_fake.rb -- --no-cov` -> 23 tests, 26 assertions, 0 failures, 0 errors.
- `env BUNDLE_PATH=/private/tmp/bundle-baza-327 mise x ruby@3.3.11 -- bundle exec rake test` -> 94 tests, 175 assertions, 0 failures, 0 errors.
- `env BUNDLE_PATH=/private/tmp/bundle-baza-327 mise x ruby@3.3.11 -- bundle exec rubocop lib/baza-rb/fake.rb test/test_fake.rb` -> 2 files inspected, no offenses.
- `env BUNDLE_PATH=/private/tmp/bundle-baza-327 mise x ruby@3.3.11 -- ruby -c lib/baza-rb/fake.rb` -> Syntax OK.
- `env BUNDLE_PATH=/private/tmp/bundle-baza-327 mise x ruby@3.3.11 -- ruby -c test/test_fake.rb` -> Syntax OK.
- `git diff --check` -> clean.
- `gitleaks detect --no-banner --redact --source . --exit-code 1` -> no leaks found.

No secrets or credentials were used.