### PR TITLE
Add nil guard to Fake#push for parity with BazaRb#push

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -38,6 +38,7 @@ class BazaRb::Fake
   # @return [Integer] Always returns 42 as the fake job ID
   def push(name, data, meta, chunk_size: BazaRb::DEFAULT_CHUNK_SIZE) # rubocop:disable Lint/UnusedMethodArgument
     checkname(name)
+    raise(RuntimeError, 'The "data" of the job is nil') if data.nil?
     raise(RuntimeError, 'The data must be non-empty') if data.empty?
     raise(RuntimeError, 'The meta must be an array') unless meta.is_a?(Array)
     42

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -32,6 +32,13 @@ class TestFake < Minitest::Test
     assert_equal(42, BazaRb::Fake.new.push('test-job', 'test-data', [], chunk_size: 1024))
   end
 
+  def test_push_raises_when_data_is_nil
+    assert_equal(
+      'The "data" of the job is nil',
+      assert_raises(RuntimeError) { BazaRb::Fake.new.push('test-job', nil, []) }.message
+    )
+  end
+
   def test_finished
     assert(BazaRb::Fake.new.finished?(42))
   end


### PR DESCRIPTION
Summary

Fixes https://github.com/zerocracy/baza.rb/issues/316.

BazaRb::Fake#push called data.empty? without first guarding against nil, so passing nil data raised a NoMethodError instead of the documented RuntimeError that the real BazaRb#push raises.

This adds the same nil check the real client uses, raising The "data" of the job is nil, restoring parity between the test double and production code (same pattern as https://github.com/zerocracy/baza.rb/issues/298, https://github.com/zerocracy/baza.rb/issues/288, https://github.com/zerocracy/baza.rb/issues/299, https://github.com/zerocracy/baza.rb/issues/309).

Changes

lib/baza-rb/fake.rb: raise RuntimeError with The "data" of the job is nil when data is nil, before the existing empty check.
test/test_fake.rb: regression test test_push_raises_when_data_is_nil.
