### PR TITLE
Fix enter() re-yielding the user block on transient POST failure

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -480,15 +480,13 @@ class BazaRb
   # @raise [ServerFailure] If the valve operation fails
   def enter(pname, badge, why, job)
     elapsed(@loog, good: "Entered valve #{badge} to #{pname}") do
-      attempt do
-        ret = get(home.append('result').add(badge:), [200, 204])
-        return ret.body if ret.code == 200
-        r = yield
-        uri = home.append('valves')
-        uri = uri.add(job:) unless job.nil?
-        post(uri, { 'badge' => badge, 'pname' => pname, 'result' => r.to_s, 'why' => why })
-        r
-      end
+      ret = get(home.append('result').add(badge:), [200, 204])
+      return ret.body if ret.code == 200
+      r = yield
+      uri = home.append('valves')
+      uri = uri.add(job:) unless job.nil?
+      post(uri, { 'badge' => badge, 'pname' => pname, 'result' => r.to_s, 'why' => why })
+      r
     end
   end
 

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -312,6 +312,27 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  # Reproduces zerocracy/baza.rb#303: BazaRb#enter wrapped the GET cache check,
+  # the user block, and the POST in a single retry region. When the POST timed
+  # out, the outer retry re-entered the whole block and ran the user's yield
+  # again. The block must execute exactly once per enter() call, even when the
+  # POST fails transiently.
+  def test_enter_yields_once_on_post_timeout
+    WebMock.disable_net_connect!
+    stub_request(:get, %r{https://example\.org:443/result}).to_return(status: 204, body: '')
+    stub_request(:get, 'https://example.org:443/csrf').to_return(body: 'token')
+    stub_request(:post, %r{https://example\.org:443/valves}).to_timeout
+    yields = 0
+    baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false, timeout: 0.1, retries: 3, pause: 0)
+    assert_raises(BazaRb::TimedOut) do
+      baza.enter('simple', 'bar', 'no reason', 42) do
+        yields += 1
+        'result'
+      end
+    end
+    assert_equal(1, yields, 'the user block must be invoked exactly once')
+  end
+
   def test_download_rejects_malformed_total_size
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
Fixes #303.

`BazaRb#enter` wrapped three operations — the GET cache check, the user `yield`
block, and the POST to `/valves` — inside a single `attempt` retry region. When
the POST timed out after exhausting its own retries, the outer `attempt` caught
the `TimedOut` and re-entered the **entire** block: GET returned 204 again, and
the user's (potentially expensive) `yield` ran a second time. With default
settings the block could be invoked up to five times for a single logical call,
breaking the API contract of one invocation per `enter`.

Since `get()` and `post()` already wrap themselves in `attempt` and retry on
timeout internally, the redundant outer wrapper in `enter` is removed. The user
block now runs exactly once; transient POST failures are still retried by `post`
itself.

## Changes
- `lib/baza-rb.rb`: removed the outer `attempt` wrapper around the
  GET / `yield` / POST sequence in `enter`.
- `test/test_baza_edge.rb`: added `test_enter_yields_once_on_post_timeout`,
  a regression test asserting the block runs exactly once even when the POST
  times out. It fails on the old code (block ran 3×) and passes after the fix.

## Test plan
- [x] `test_enter_yields_once_on_post_timeout` passes
- [x] Existing Pact tests `test_enters_when_cached` / `test_enters_when_not_cached` pass
- [x] Rubocop clean on changed files