### PR TITLE
download: anchor Content-Range range guard regex (#302)

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -826,7 +826,7 @@ class BazaRb
         raise(RuntimeError, "Total size is not valid (#{total.inspect})") unless total.match?(/\A(?:\*|[0-9]+)\z/)
         _b, e = range.split('-', 2)
         raise(RuntimeError, "Range is not valid (#{range.inspect})") if e.nil?
-        raise(RuntimeError, "Range is not valid (#{range.inspect})") unless e.match?(/^[0-9]+$/)
+        raise(RuntimeError, "Range is not valid (#{range.inspect})") unless e.match?(/\A[0-9]+\z/)
         break if e.to_i == total.to_i - 1
         break if total == '0'
         chunk += 1

--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -821,7 +821,7 @@ class BazaRb
         end
         @loog.debug(msg.compact.join(', '))
         break if ret.code == 200
-        _, v = ret.headers['Content-Range'].split
+        _, v = ret.headers['Content-Range'].split(' ', 2)
         range, total = v.split('/')
         raise(RuntimeError, "Total size is not valid (#{total.inspect})") unless total.match?(/\A(?:\*|[0-9]+)\z/)
         _b, e = range.split('-', 2)

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -328,6 +328,22 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_download_rejects_malformed_range_end
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'download.txt')
+      stub_request(:get, 'https://example.org:443/file')
+        .with(headers: { 'Range' => 'bytes=0-' })
+        .to_return(status: 206, body: 'x', headers: { 'Content-Range' => "bytes 0-0\njunk/10" })
+      assert_includes(
+        assert_raises(RuntimeError) do
+          fake_baza.__send__(:download, fake_baza.__send__(:home).append('file'), file)
+        end.message,
+        'Range is not valid'
+      )
+    end
+  end
+
   def test_upload_retries_on_busy_server
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
Fixes #302.

The total-size guard in `lib/baza-rb.rb` is already anchored with
`/\A(?:\*|[0-9]+)\z/`, but the adjacent range guard still used
`/^[0-9]+$/`. In Ruby, `^` and `$` match line boundaries rather than
string boundaries, so a multiline value such as `"abc\n123"` would pass
validation and then be coerced by `.to_i` to `0` or a partial integer.

This PR anchors the range guard with `\A...\z` so it matches the entire
string, consistent with the total-size guard:

- `lib/baza-rb.rb`: `/^[0-9]+$/` → `/\A[0-9]+\z/`

Verified with `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n '/download/'`
(all download tests pass) and `rubocop` (no offenses).