### PR TITLE
#332: guard push meta type

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -109,6 +109,7 @@ class BazaRb
     raise(RuntimeError, 'The "name" of the job may not be empty') if pname.empty?
     raise(RuntimeError, 'The "data" of the job is nil') if data.nil?
     raise(RuntimeError, 'The "meta" of the job is nil') if meta.nil?
+    raise(RuntimeError, 'The "meta" of the job must be an Array') unless meta.is_a?(Array)
     elapsed(@loog, level: Logger::INFO) do
       Tempfile.open do |file|
         File.binwrite(file.path, data)

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -84,6 +84,15 @@ class TestBazaRbEdge < Minitest::Test
     )
   end
 
+  def test_push_rejects_non_array_meta
+    assert_includes(
+      assert_raises(RuntimeError) do
+        fake_baza.push('simple', 'hello, world!', 'boom!')
+      end.message,
+      'The "meta" of the job must be an Array'
+    )
+  end
+
   def test_push_compressed_content
     WebMock.enable_net_connect!
     fb = Factbase.new


### PR DESCRIPTION
/claim #332

Closes #332.

Summary:
- Add the missing `Array` boundary guard to `BazaRb#push` for the `meta` argument, next to the existing nil guard.
- Add a regression proving a bare string is rejected before the upload/header path.

Validation:
- `bundle exec ruby test/test_baza_edge.rb -n test_push_rejects_non_array_meta -- --no-cov` -> 1 test, 3 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby test/test_baza_edge.rb -- --no-cov` -> 39 tests, 111 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb --format simple` -> 2 files inspected, no offenses detected.
- `ruby -c lib/baza-rb.rb && ruby -c test/test_baza_edge.rb` -> Syntax OK for both files.
- `git diff --check` -> clean.
- `git diff --no-ext-diff upstream/master | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Not run:
- Full `bundle exec rake test`, because `test/test_baza_live.rb` makes live `api.zerocracy.com` calls and this ROE is local-only.

No wallet, payout, signing, production mutation, or destructive action was performed.
