### PR TITLE
#299: accept durable names in fake find

### DIFF
--- a/lib/baza-rb/fake.rb
+++ b/lib/baza-rb/fake.rb
@@ -127,11 +127,12 @@ class BazaRb::Fake
   # Find a single durable.
   #
   # @param [String] pname The name of the job on the server
-  # @param [String] file The path to the file to upload
+  # @param [String] file The file name
   # @return [Integer] Always returns 42 as the fake durable ID
   def durable_find(pname, file)
     checkname(pname)
-    checkfile(file)
+    raise(RuntimeError, 'The "file" is nil') if file.nil?
+    raise(RuntimeError, 'The "file" may not be empty') if file.empty?
     42
   end
 

--- a/test/test_fake.rb
+++ b/test/test_fake.rb
@@ -105,6 +105,24 @@ class TestFake < Minitest::Test
     end
   end
 
+  def test_durable_find_accepts_nonexistent_file_name
+    assert_equal(42, BazaRb::Fake.new.durable_find('test-job', 'remote.bin'))
+  end
+
+  def test_durable_find_rejects_nil_file_name
+    assert_equal(
+      'The "file" is nil',
+      assert_raises(RuntimeError) { BazaRb::Fake.new.durable_find('test-job', nil) }.message
+    )
+  end
+
+  def test_durable_find_rejects_empty_file_name
+    assert_equal(
+      'The "file" may not be empty',
+      assert_raises(RuntimeError) { BazaRb::Fake.new.durable_find('test-job', '') }.message
+    )
+  end
+
   def test_durable_load_raises_when_file_is_nil
     assert_equal(
       'The "file" of the durable is nil',


### PR DESCRIPTION
/claim #299

Closes #299.

Summary:
- Align `BazaRb::Fake#durable_find` with the real client by treating `file` as a durable file name, not as a local file path.
- Keep nil and empty filename guards consistent with `BazaRb#durable_find`.
- Add regression coverage proving nonexistent remote file names are accepted and nil/empty names are rejected.

Validation:
- `ruby -c lib\\baza-rb\\fake.rb` -> `Syntax OK`
- `ruby -c test\\test_fake.rb` -> `Syntax OK`
- `bundle check` -> dependencies satisfied after `bundle install`
- focused fake test via Ruby loader with coverage disabled -> `39` tests, `51` assertions, `0` failures, `0` errors
- `bundle exec rubocop lib\\baza-rb\\fake.rb test\\test_fake.rb` -> `2` files inspected, no offenses
- `bundle exec rake rubocop` -> `12` files inspected, no offenses
- `bundle exec rake yard` -> `96.23%` documented
- `git diff --check origin/master..HEAD` -> clean
- `git diff --no-ext-diff origin/master..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Limitations:
- `bundle exec rake test` did execute the full suite far enough to run the new `TestFake` cases, and the suite reported `111` tests, `199` assertions, `0` failures, `3` errors, coverage `99.61%`.
- The three full-suite errors were Windows/environment issues outside this patch: `/bin/bash` missing in the Sinatra helper and two temp-file cleanup `Errno::EACCES` errors in durable tests. The focused `TestFake` run above passed cleanly.

No secrets are included in the diff.