### PR TITLE
#337: validate transfer inputs

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -419,10 +419,16 @@ class BazaRb
   # @raise [ServerFailure] If the transfer fails
   def transfer(recipient, amount, summary, job: nil)
     raise(RuntimeError, 'The "recipient" is nil') if recipient.nil?
+    raise(RuntimeError, "The recipient #{recipient.inspect} is not valid") unless recipient.match?(/\A[a-zA-Z0-9-]+\z/)
     raise(RuntimeError, 'The "amount" is nil') if amount.nil?
     raise(RuntimeError, 'The "amount" must be Float') unless amount.is_a?(Float)
     raise(RuntimeError, 'The "amount" must be positive') unless amount.positive?
     raise(RuntimeError, 'The "summary" is nil') if summary.nil?
+    raise(RuntimeError, "The summary #{summary.inspect} is empty") if summary.empty?
+    unless job.nil?
+      raise(RuntimeError, 'The ID must be an Integer') unless job.is_a?(Integer)
+      raise(RuntimeError, 'The ID must be positive') unless job.positive?
+    end
     id = nil
     body = { 'human' => recipient, 'amount' => format('%0.6f', amount), 'summary' => summary }
     body['job'] = job unless job.nil?

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -530,6 +530,28 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_transfer_raises_when_recipient_is_invalid
+    ['', "jeff\nbad", 'jeff@example.com'].each do |recipient|
+      assert_equal(
+        "The recipient #{recipient.inspect} is not valid",
+        assert_raises(RuntimeError) { fake_baza.transfer(recipient, 1.0, 'pay') }.message
+      )
+    end
+  end
+
+  def test_transfer_raises_when_summary_is_empty
+    assert_equal(
+      'The summary "" is empty',
+      assert_raises(RuntimeError) { fake_baza.transfer('jeff', 1.0, '') }.message
+    )
+  end
+
+  def test_transfer_raises_when_job_is_invalid
+    [['1', 'The ID must be an Integer'], [0, 'The ID must be positive']].each do |job, message|
+      assert_equal(message, assert_raises(RuntimeError) { fake_baza.transfer('jeff', 1.0, 'pay', job:) }.message)
+    end
+  end
+
   def test_fee_raises_when_amount_is_not_positive
     [0.0, -1.0, -0.000001].each do |amount|
       assert_equal(


### PR DESCRIPTION
/claim #337
Fixes #337

## Summary
- Validate the real `BazaRb#transfer` recipient with the same GitHub-login pattern used by `BazaRb::Fake#transfer`.
- Reject empty transfer summaries before the POST body is built.
- Validate optional `job:` values as positive integers before sending them to the server.
- Add edge tests covering the new real-client guard behavior.

## Validation
- `mise x ruby@3.3 -- ruby -c lib/baza-rb.rb && mise x ruby@3.3 -- ruby -c test/test_baza_edge.rb`
- `mise x ruby@3.3 -- bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb`
- `git diff --check`
- `gitleaks protect --no-banner --redact --source . --log-opts="origin/master..HEAD"`
- `mise x ruby@3.3 -- bundle exec ruby -w -Ilib:test /Users/mx/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rake-13.4.2/lib/rake/rake_test_loader.rb test/test_baza.rb test/test_baza_edge.rb test/test_fake.rb`

The default `rake test` was not used as final validation because it starts `test/test_baza_live.rb`; I stopped that path and ran the non-live suite above instead. No secrets or live payment data are included in this PR.
