### PR TITLE
#339: guard download Content-Range

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -796,18 +796,19 @@ class BazaRb
               [200, 206, 204, 302]
             )
           end
+        rheaders = ret.headers || {}
         msg = [
           "GET #{uri.to_uri.path} #{ret.code}",
           "#{slice.bytesize} bytes",
-          ('in gzip' if ret.headers['Content-Encoding'] == 'gzip'),
-          ("ranged as #{ret.headers['Content-Range'].inspect}" if ret.headers['Content-Range'])
+          ('in gzip' if rheaders['Content-Encoding'] == 'gzip'),
+          ("ranged as #{rheaders['Content-Range'].inspect}" if rheaders['Content-Range'])
         ]
         uri = rehost(ret, uri)
         if blanks.include?(ret.code)
           sleep(2)
           next
         end
-        if ret.headers['Content-Encoding'] == 'gzip'
+        if rheaders['Content-Encoding'] == 'gzip'
           begin
             slice = unzip(slice)
             msg << "unzipped to #{slice.bytesize} bytes"
@@ -821,8 +822,7 @@ class BazaRb
         end
         @loog.debug(msg.compact.join(', '))
         break if ret.code == 200
-        _, v = ret.headers['Content-Range'].split
-        range, total = v.split('/')
+        range, total = crange(rheaders)
         raise(RuntimeError, "Total size is not valid (#{total.inspect})") unless total.match?(/\A(?:\*|[0-9]+)\z/)
         _b, e = range.split('-', 2)
         raise(RuntimeError, "Range is not valid (#{range.inspect})") if e.nil?
@@ -830,10 +830,20 @@ class BazaRb
         break if e.to_i == total.to_i - 1
         break if total == '0'
         chunk += 1
-        sleep(1) if ret.headers['Content-Length'].to_i.zero?
+        sleep(1) if rheaders['Content-Length'].to_i.zero?
       end
       throw(:"Downloaded #{File.size(file)} bytes in #{chunk + 1} chunks from #{uri}")
     end
+  end
+
+  def crange(headers)
+    crange = headers['Content-Range']
+    raise(RuntimeError, 'Content-Range header is missing') if crange.nil?
+    _, value = crange.split
+    raise(RuntimeError, "Content-Range is not valid (#{crange.inspect})") if value.nil?
+    range, total = value.split('/', 2)
+    raise(RuntimeError, "Content-Range is not valid (#{crange.inspect})") if total.nil?
+    [range, total]
   end
 
   # Upload file via PUT, using chunked uploads for large files.

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -167,6 +167,36 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_durable_load_rejects_missing_content_range
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'loaded.txt')
+      stub_request(:get, 'https://example.org:443/durables/42')
+        .with(headers: { 'Range' => 'bytes=0-' })
+        .to_return(status: 206, body: 'x')
+      assert_includes(
+        assert_raises(RuntimeError) do
+          fake_baza.durable_load(42, file)
+        end.message, 'Content-Range header is missing'
+      )
+    end
+  end
+
+  def test_durable_load_rejects_range_without_total
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'loaded.txt')
+      stub_request(:get, 'https://example.org:443/durables/42')
+        .with(headers: { 'Range' => 'bytes=0-' })
+        .to_return(status: 206, body: 'x', headers: { 'Content-Range' => 'bytes 0-499' })
+      assert_includes(
+        assert_raises(RuntimeError) do
+          fake_baza.durable_load(42, file)
+        end.message, 'Content-Range is not valid ("bytes 0-499")'
+      )
+    end
+  end
+
   def test_durable_load_with_broken_compression
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
/claim #339
Fixes #339

## Summary
- Treat a 206 response with no `Content-Range` header as a clean `RuntimeError` instead of letting nil headers crash the downloader.
- Reject malformed `Content-Range` values with no `/total` part before calling `match?` on nil.
- Add regression coverage for the missing-header and missing-total cases next to the existing no-hyphen guard.

## Validation
- Pre-fix reproduction: the new focused tests failed with `NoMethodError: undefined method '[]' for nil` and `NoMethodError: undefined method 'match?' for nil` before the source change.
- `bundle exec ruby -Itest test/test_baza_edge.rb --name test_durable_load_rejects_missing_content_range -- --no-cov` -> 1 test, 3 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest test/test_baza_edge.rb --name test_durable_load_rejects_range_without_total -- --no-cov` -> 1 test, 3 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest test/test_baza_edge.rb --name test_durable_load_rejects_range_without_hyphen -- --no-cov` -> 1 test, 3 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest test/test_baza.rb -- --no-cov` -> 26 tests, 22 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest test/test_fake.rb -- --no-cov` -> 36 tests, 46 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` -> 2 files inspected, no offenses detected.
- `ruby -c lib/baza-rb.rb; ruby -c test/test_baza_edge.rb` -> Syntax OK for both files.
- `git diff --check` -> clean.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

## Not run
- Full `test/test_baza_edge.rb` on this Windows host: two host-specific paths failed outside this patch (`test_durable_place` temp-file cleanup `Errno::EACCES`, and `test_durable_load_from_sinatra` requiring `/bin/bash`).
- Docker Linux validation: `docker` is not installed in this environment.

No wallet, payout, signing, production mutation, or destructive action was performed.