### PR TITLE
#276 correct retries default in BazaRb#initialize YARD doc

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -55,7 +55,7 @@ class BazaRb
   # @param [String] token Your Zerocracy API authentication token
   # @param [Boolean] ssl Whether to use SSL/HTTPS (default: true)
   # @param [Float] timeout Connection and request timeout in seconds (default: 30)
-  # @param [Integer] retries Number of retries on connection failure (default: 3)
+  # @param [Integer] retries Number of retries on connection failure (default: 5)
   # @param [Integer] pause The factor on pause (<1 means faster, >1 means slower)
   # @param [Loog] loog The logging facility (default: Loog::NULL)
   # @param [Boolean] compress Whether to use GZIP compression for requests/responses (default: true)


### PR DESCRIPTION
Closes #276.

The YARD `@param` line for `retries:` in `BazaRb#initialize` documents `(default: 3)`, but the keyword default in the constructor signature is `retries: 5`. The doc string is corrected to match the actual default, so callers reading the YARD documentation get the right retry budget and any tooling that surfaces defaults from the docs is no longer off by two.

The change is a one-line edit in `lib/baza-rb.rb:58`; no source code, signature, or test fixture is touched.

Verified locally with `bundle exec rake rubocop` (12 files, 0 offenses) and `bundle exec rake yard` (45 methods documented, 96.23% coverage, 0 warnings).
