### PR TITLE
fix: #344 guard BazaRb#push against empty data

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -108,6 +108,7 @@ class BazaRb
     raise(RuntimeError, 'The "name" of the job is nil') if pname.nil?
     raise(RuntimeError, 'The "name" of the job may not be empty') if pname.empty?
     raise(RuntimeError, 'The "data" of the job is nil') if data.nil?
+    raise(RuntimeError, 'The "data" of the job may not be empty') if data.empty?
     raise(RuntimeError, 'The "meta" of the job is nil') if meta.nil?
     elapsed(@loog, level: Logger::INFO) do
       Tempfile.open do |file|

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -521,6 +521,13 @@ class TestBazaRbEdge < Minitest::Test
     )
   end
 
+  def test_push_raises_when_data_is_empty
+    assert_equal(
+      'The "data" of the job may not be empty',
+      assert_raises(RuntimeError) { fake_baza.push('pname', '', []) }.message
+    )
+  end
+
   def test_transfer_raises_when_amount_is_not_positive
     [0.0, -1.0, -0.000001].each do |amount|
       assert_equal(


### PR DESCRIPTION
Closes #344. The real client's `BazaRb#push` in `lib/baza-rb.rb` accepts an empty string for `data` and forwards a zero-byte payload through the upload pipeline, while `BazaRb::Fake#push` already raises `The data must be non-empty` for the same input. The drift hides defective callers behind passing Fake tests and surfaces only as a server-side rejection on real traffic.

A single guard between the existing `data.nil?` and `meta.nil?` checks on line 110 restores parity: the real client now raises `'The "data" of the job may not be empty'` for an empty string. A new `test_push_raises_when_data_is_empty` case in `test/test_baza_edge.rb`, next to the existing `*_raises_when_*` cases, pins the guard.

Local checks on Ruby 3.3.6: `bundle exec ruby test/test_baza_edge.rb -n test_push_raises_when_data_is_empty` -> 1 test, 2 assertions, 0 failures; `bundle exec rake test` -> 109 tests, 1 failure and 7 errors all reproducing on `origin/master` (`test_durable_load_in_chunks`, `test_real_http`, the four `test_push_with_*`/`test_push_compress*` cases, `test_with_very_short_timeout`, `test_durable_load_from_sinatra`) and unrelated to this diff; `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` -> no offenses; `bundle exec yard --fail-on-warning lib/**/*.rb` -> 96% documented, no warnings.