### PR TITLE
fix: #341 align attempt retry count with await and recover

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -603,7 +603,7 @@ class BazaRb
   # @yield The block to execute with retries
   # @return [Object] The result of the block execution
   def attempt(&)
-    with_retries(max_tries: @retries, rescue: TimedOut, &)
+    with_retries(max_tries: @retries + 1, rescue: TimedOut, &)
   end
 
   # Execute a block with retries on 429 status codes.

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -290,6 +290,23 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  # Reproduces zerocracy/baza.rb#341: BazaRb#attempt passed @retries to
+  # with_retries(max_tries:), so a retries: N configuration produced N-1
+  # retries on TimedOut while #await and #recover gave N retries on 429
+  # and >=499. After the fix, attempt allows @retries + 1 total tries to
+  # match the retry count semantics of the surrounding loops.
+  def test_attempt_total_tries_match_retries_plus_one
+    fast = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, retries: 3, pause: 0)
+    attempts = 0
+    assert_raises(BazaRb::TimedOut) do
+      fast.__send__(:attempt) do
+        attempts += 1
+        raise(BazaRb::TimedOut, 'simulated timeout')
+      end
+    end
+    assert_equal(4, attempts, 'attempt must run @retries + 1 total tries on a persistent TimedOut')
+  end
+
   # Reproduces zerocracy/baza.rb#289: BazaRb#download never retries on
   # timeout because checked() is called outside attempt. After the fix,
   # a libcurl operation_timedout on the first GET re-raises BazaRb::TimedOut


### PR DESCRIPTION
Issue #341 noticed that `BazaRb#attempt` passed `@retries` to `with_retries(max_tries:)` while `#await` and `#recover` treated `@retries` as a retry count, so a `retries: 5` configuration produced four `TimedOut` retries against five `429` and `>=499` retries. The YARD on `lib/baza-rb.rb:58` names the kwarg "Number of retries on connection failure", which matches the loop semantics in `await` and `recover` and contradicts the `with_retries` semantics in `attempt`.

The diff bumps `max_tries:` in `attempt` to `@retries + 1` so all three retry layers interpret the constructor's `retries:` kwarg as the same retry count. The visible effect is that a `BazaRb.new(host, port, token, retries: N)` now performs `N + 1` total tries on `TimedOut`, `429`, and `>=499` — one initial call and `N` retries on each path. The new `test_attempt_total_tries_match_retries_plus_one` in `test/test_baza_edge.rb` pins the count at `@retries + 1` total tries on a persistent `TimedOut`.

Local checks on Ruby 3.3.6: `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n test_attempt_total_tries_match_retries_plus_one` -> 1 test, 2 assertions, 0 failures; `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n '/retries|retry|attempt|partial_file/'` -> 8 tests, 21 assertions, 0 failures; `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb` -> 39 tests, 1 failure and 7 errors all reproducing on `origin/master` (`test_durable_load_in_chunks`, `test_real_http`, the four `test_push_with_*`/`test_push_compress*` cases, `test_with_very_short_timeout`, `test_durable_load_from_sinatra`) and unrelated to this diff; `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` -> no offenses; `bundle exec yard --fail-on-warning 'lib/**/*.rb'` -> 96.23% documented, no warnings.

Closes #341.
