### PR TITLE
#345: Fix Content-Type application/zip on gzip-encoded upload bodies

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -586,13 +586,7 @@ class BazaRb
     body = io.string
     params.merge(
       body:,
-      headers: params.fetch(:headers).merge(
-        {
-          'Content-Type' => 'application/zip',
-          'Content-Encoding' => 'gzip',
-          'Content-Length' => body.bytesize
-        }
-      )
+      headers: params.fetch(:headers).merge({ 'Content-Encoding' => 'gzip', 'Content-Length' => body.bytesize })
     )
   end
 

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -101,7 +101,7 @@ class TestBazaRbEdge < Minitest::Test
       with_http(200, 'yes') do |baza|
         baza.push('simple', fb.export, %w[meta1 meta2 meta3])
       end
-    assert_equal('application/zip', req.content_type)
+    assert_equal('application/octet-stream', req.content_type)
     assert_equal('gzip', req['content-encoding'])
     assert_equal(fb.export, Zlib::GzipReader.zcat(StringIO.new(req.body)))
   end
@@ -116,6 +116,22 @@ class TestBazaRbEdge < Minitest::Test
       end
     assert_equal('application/octet-stream', req.content_type)
     assert_equal(fb.export, req.body)
+  end
+
+  def test_push_compressed_headers_are_correct
+    WebMock.disable_net_connect!
+    stub_request(:put, 'https://example.org:443/push/test-pname')
+      .with(
+        headers: {
+          'Content-Type' => 'application/octet-stream',
+          'Content-Encoding' => 'gzip'
+        }
+      )
+      .to_return(status: 200, body: '')
+    BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: true, timeout: 0.1, retries: 2).push(
+      'test-pname', 'some data', ['meta']
+    )
+    assert_requested(:put, 'https://example.org:443/push/test-pname', times: 1)
   end
 
   def test_with_very_short_timeout


### PR DESCRIPTION
## Problem

`BazaRb#zipped` set `Content-Type: application/zip` on gzip-compressed upload bodies. The body is a gzip stream (written by `Zlib::GzipWriter`), not a ZIP archive. The `Content-Encoding: gzip` header already names the transport encoding. The wrong media type causes servers that route by `Content-Type` before decoding to reject legitimate uploads.

## Solution

Removed `'Content-Type' => 'application/zip'` from the `zipped` method. The original `Content-Type: application/octet-stream` set by `upload` now survives through compression. Only `Content-Encoding: gzip` and `Content-Length` are added when compression is on.

## Verification
- [x] `bundle exec rubocop` — 0 offenses
- [x] All tests pass (46 edge tests, 132 assertions)
- [x] Updated `test_push_compressed_content` to expect `application/octet-stream`
- [x] New test `test_push_compressed_headers_are_correct` verifies both headers via WebMock

Closes #345.
