### PR TITLE
#345 drop application/zip content-type from gzipped uploads

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -586,13 +586,7 @@ class BazaRb
     body = io.string
     params.merge(
       body:,
-      headers: params.fetch(:headers).merge(
-        {
-          'Content-Type' => 'application/zip',
-          'Content-Encoding' => 'gzip',
-          'Content-Length' => body.bytesize
-        }
-      )
+      headers: params.fetch(:headers).merge({ 'Content-Encoding' => 'gzip', 'Content-Length' => body.bytesize })
     )
   end
 

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -101,7 +101,7 @@ class TestBazaRbEdge < Minitest::Test
       with_http(200, 'yes') do |baza|
         baza.push('simple', fb.export, %w[meta1 meta2 meta3])
       end
-    assert_equal('application/zip', req.content_type)
+    assert_equal('application/octet-stream', req.content_type)
     assert_equal('gzip', req['content-encoding'])
     assert_equal(fb.export, Zlib::GzipReader.zcat(StringIO.new(req.body)))
   end


### PR DESCRIPTION
Closes #345.

`BazaRb#zipped` was overwriting `Content-Type` with `application/zip` whenever `@compress` was true, mislabeling the gzip-encoded octet-stream as a ZIP archive. The override is dropped so the `application/octet-stream` set by `upload` survives alongside `Content-Encoding: gzip`.

Requests with compression on now carry `Content-Type: application/octet-stream` and `Content-Encoding: gzip` together; requests with compression off are unchanged. The `test_push_compressed_content` assertion is updated to pin the new contract.

`bin/rubocop` is clean on the changed files. `bin/rake test` was run locally; the unit suites pass except for the network-bound cases that need IPv6 loopback in the container, which fail identically on master (`Errno::EAFNOSUPPORT` on `::1`), and one live test that depends on the production API.
