### PR TITLE
#341: Fix retry count inconsistency - attempt was one short of await/recover

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -635,7 +635,7 @@ class BazaRb
   # @yield The block to execute with retries
   # @return [Object] The result of the block execution
   def attempt(&)
-    with_retries(max_tries: @retries, rescue: TimedOut, &)
+    with_retries(max_tries: @retries + 1, rescue: TimedOut, &)
   end
 
   # Retry the HTTP request on rate-limiting (429) and server errors (>= 499).


### PR DESCRIPTION
## Problem

`attempt` used `with_retries(max_tries: @retries)` where `max_tries` is the total attempt count (1 initial + N-1 retries). `await`/`recover` used `attempt < @retries` for up to @retries retries (1 initial + @retries retries). So timeout retries were consistently one short of 429/5xx retries.

## Solution

Changed `max_tries: @retries` to `max_tries: @retries + 1` in `attempt`, so all three retry layers treat `@retries` as the retry count (matching the YARD doc and user expectation).

## Verification
- [x] `bundle exec rubocop` — 0 offenses
- [x] All tests pass
- [x] `test_download_retries_on_timeout` still passes (was already using a single retry)

Closes #341.