### PR TITLE
#303: Fix enter re-yielding user block on transient POST failure

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -488,15 +488,13 @@ class BazaRb
   # @raise [ServerFailure] If the valve operation fails
   def enter(pname, badge, why, job)
     elapsed(@loog, good: "Entered valve #{badge} to #{pname}") do
-      attempt do
-        ret = get(home.append('result').add(badge:), [200, 204])
-        return ret.body if ret.code == 200
-        r = yield
-        uri = home.append('valves')
-        uri = uri.add(job:) unless job.nil?
-        post(uri, { 'badge' => badge, 'pname' => pname, 'result' => r.to_s, 'why' => why })
-        r
-      end
+      ret = get(home.append('result').add(badge:), [200, 204])
+      return ret.body if ret.code == 200
+      r = yield
+      uri = home.append('valves')
+      uri = uri.add(job:) unless job.nil?
+      post(uri, { 'badge' => badge, 'pname' => pname, 'result' => r.to_s, 'why' => why })
+      r
     end
   end
 

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -801,6 +801,39 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_enter_yields_once_on_transient_post_failure
+    WebMock.disable_net_connect!
+    csrf = 'swordfish'
+    stub_request(:get, 'https://example.org:443/result?badge=test-badge').to_return(status: 204, body: '')
+    stub_request(:get, 'https://example.org:443/csrf').to_return(status: 200, body: csrf)
+    stub_request(:post, 'https://example.org:443/valves')
+      .with(
+        body: {
+          '_csrf' => csrf,
+          'badge' => 'test-badge',
+          'pname' => 'test',
+          'result' => 'computed',
+          'why' => 'testing'
+        }
+      )
+      .to_timeout.then
+      .to_return(status: 302, headers: {})
+    baza = BazaRb.new(
+      'example.org', 443, '000',
+      loog: Loog::NULL, compress: false, timeout: 0.1, retries: 2, pause: 0
+    )
+    yld = 0
+    assert_equal(
+      'computed',
+      baza.enter('test', 'test-badge', 'testing', nil) do
+        yld += 1
+        'computed'
+      end
+    )
+    assert_equal(1, yld, 'User block must yield exactly once')
+    assert_requested(:post, 'https://example.org:443/valves', times: 2)
+  end
+
   private
 
   def with_sinatra


### PR DESCRIPTION
## Problem

`BazaRb#enter` wrapped the GET cache check, the `yield` to the user block, and the POST to `/valves` inside a single `attempt`. When the POST timed out (after exhausting its own internal retries), the outer `attempt` would catch `TimedOut` and retry the entire block — re-running the user's `yield`. With the default `retries: 5`, the user block could run up to 5 times for a single logical `enter` call.

## Solution

Removed the outer `attempt do ... end` wrapper from `enter`. Both `get` and `post` already have their own complete retry chains (`attempt` → `recover` → `await`), so the outer wrapper was redundant. The `yield` now runs at most once per `enter` call.

## Verification
- `bundle exec rubocop` — 0 offenses
- All tests pass (46 edge tests, 134 assertions)
- New test `test_enter_yields_once_on_transient_post_failure` confirms the user block runs exactly once even when the POST retries internally

Closes #303.
