### PR TITLE
#361: cache CSRF token with 10 min TTL

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -69,6 +69,8 @@ class BazaRb
     @retries = retries
     @pause = pause
     @compress = compress
+    @tokn = nil
+    @exp = Time.now - 1
   end
 
   # Get GitHub login name of the logged in user.
@@ -508,12 +510,16 @@ class BazaRb
   # @return [String] The CSRF token for the authenticated user
   # @raise [ServerFailure] If token retrieval fails
   def csrf
-    token = nil
-    elapsed(@loog, level: Logger::INFO) do
-      token = get(home.append('csrf')).body
-      throw(:"CSRF token retrieved (#{token.length} chars)")
+    if @tokn.nil? || @exp < Time.now
+      token = nil
+      elapsed(@loog, level: Logger::INFO) do
+        token = get(home.append('csrf')).body
+        throw(:"CSRF token retrieved (#{token.length} chars)")
+      end
+      @tokn = token
+      @exp = Time.now + 600
     end
-    token
+    @tokn
   end
 
   private


### PR DESCRIPTION
## Problem

Every POST method (push, unlock, transfer, enter, etc.) fetched a CSRF token from `/csrf` before making the actual POST, doubling HTTP round-trips. CSRF tokens typically have a TTL of several minutes, so fetching one per POST is wasteful.

## Solution

Cache the CSRF token with a 10-minute TTL:
- Added `@tokn` and `@exp` instance variables
- On first call, fetch from `/csrf` and cache the result
- Subsequent calls within 10 minutes use the cached token
- After expiry, the next call re-fetches automatically

## Verification
- [x] `bundle exec rubocop` — 0 offenses
- [x] All tests pass (26 pact, 45 edge)
- [x] Cached token is used within TTL, re-fetched after expiry

Closes #361.
