### PR TITLE
#359 guard @host mutation in rehost with a Mutex

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -69,6 +69,7 @@ class BazaRb
     @retries = retries
     @pause = pause
     @compress = compress
+    @mutex = Mutex.new
   end
 
   # Get GitHub login name of the logged in user.
@@ -527,11 +528,13 @@ class BazaRb
     return uri unless sticky
     return uri unless hostname?(sticky)
     host = sticky.strip.chomp('.')
-    if host != @host
-      @loog.debug("Switching host from #{@host} to #{host} as per X-Zerocracy-Host")
-      @host = host
+    @mutex.synchronize do
+      if host != @host
+        @loog.debug("Switching host from #{@host} to #{host} as per X-Zerocracy-Host")
+        @host = host
+      end
+      uri.host(@host)
     end
-    uri.host(@host)
   end
 
   # Validate hostname format according to RFC 1123.

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -590,6 +590,27 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_rehost_is_thread_safe
+    baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false)
+    candidates = (1..16).map { |i| "server#{i}.example.org" }
+    barrier = Queue.new
+    candidates.map do |name|
+      Thread.new do
+        barrier.pop
+        ret = Struct.new(:headers).new({ 'X-Zerocracy-Host' => name })
+        50.times { baza.__send__(:rehost, ret, baza.__send__(:home)) }
+      end
+    end.tap do |ts|
+      candidates.size.times { barrier << :go }
+      ts.each(&:join)
+    end
+    assert_includes(
+      candidates,
+      baza.instance_variable_get(:@host),
+      'rehost should leave @host at one of the candidate hostnames'
+    )
+  end
+
   def test_lock_raises_when_owner_is_empty
     assert_equal(
       'The "owner" of the lock may not be empty',


### PR DESCRIPTION
Issue #359 reported that `BazaRb#rehost` reads and writes `@host` without any synchronization, so two concurrent `download`/`upload` calls hitting a sticky-host response could race on the write and route a subsequent request — carrying the authentication token — to the unintended host.

This change initializes `@mutex = Mutex.new` in the constructor and wraps the read-modify-write block in `rehost` with `@mutex.synchronize`, so the comparison, the optional reassignment, and the return value all observe a consistent `@host`. No public signature changes.

Ran `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` (clean), `bundle exec yardoc --fail-on-warning lib/**/*.rb` (clean), and `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb` locally. The new `test_rehost_is_thread_safe` passes; the eight other failures/errors observed in this file (`test_real_http`, `test_with_very_short_timeout`, `test_push_*`, `test_durable_load_*`) reproduce unchanged on `master` without this patch, so they are pre-existing.

Closes #359
