### PR TITLE
fix: #349 close 'zip' descriptor in BazaRb#durable_place

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -307,14 +307,16 @@ class BazaRb
     end
     id = nil
     elapsed(@loog, level: Logger::INFO) do
-      id = post(
-        home.append('durable-place'),
-        {
-          'pname' => pname,
-          'file' => File.basename(file),
-          'zip' => File.open(file, 'rb')
-        }
-      ).headers['X-Zerocracy-DurableId'].to_i
+      File.open(file, 'rb') do |zip|
+        id = post(
+          home.append('durable-place'),
+          {
+            'pname' => pname,
+            'file' => File.basename(file),
+            'zip' => zip
+          }
+        ).headers['X-Zerocracy-DurableId'].to_i
+      end
       throw(:"Durable ##{id} (#{file}, #{File.size(file)} bytes) placed for job \"#{pname}\" at #{@host}")
     end
     id

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -49,6 +49,28 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_durable_place_closes_zip
+    WebMock.disable_net_connect!
+    baza = fake_baza(compress: false)
+    stub_request(:get, 'https://example.org/csrf').to_return(body: 'token')
+    stub_request(:post, 'https://example.org/durable-place').to_return(
+      status: 302, headers: { 'X-Zerocracy-DurableId' => '7' }
+    )
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'tiny.bin')
+      File.binwrite(file, 'x')
+      assert_equal(7, baza.durable_place('simple', file))
+      leaked =
+        ObjectSpace.each_object(File).select do |f|
+          next false if f.closed?
+          f.path == file
+        rescue IOError
+          false
+        end
+      assert_empty(leaked, "durable_place left #{leaked.size} open IO(s) for #{file}")
+    end
+  end
+
   def test_real_http
     WebMock.enable_net_connect!
     assert_equal(


### PR DESCRIPTION
Closes #349. BazaRb#durable_place at lib/baza-rb.rb:308-320 opened the file for the multipart `zip` field with a bare `File.open(file, 'rb')` and never closed the descriptor; in a long-running process the file table grows linearly with calls until `Errno::EMFILE` fires.

The post call is now wrapped in `File.open(file, 'rb') do |zip| ... end`, so the IO is closed on every path out of the elapsed block. Behavior of the happy path is unchanged: the existing `test_durable_place` still passes against the same multipart stub. A new regression test, `test_durable_place_closes_zip`, scans `ObjectSpace.each_object(File)` after the call and asserts that no open IO is still pointing at the uploaded file.

Ran `bundle exec ruby -Ilib -Itest test/test_baza_edge.rb -n /durable_place/` locally (both tests pass, 5 assertions, no failures) and `rubocop lib/baza-rb.rb test/test_baza_edge.rb` (0 offenses). The unrelated suite-wide errors on this machine come from `random-port` trying to bind `::1`, which is disabled in the sandbox; CI on GitHub Actions runs the full matrix.
