### PR TITLE
Validate non-empty summary in fee()

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -458,6 +458,7 @@ class BazaRb
     raise(RuntimeError, 'The "job" is nil') if job.nil?
     raise(RuntimeError, 'The "job" must be Integer') unless job.is_a?(Integer)
     raise(RuntimeError, 'The "summary" is nil') if summary.nil?
+    raise(RuntimeError, "The summary #{summary.inspect} is empty") if summary.empty?
     id = nil
     elapsed(@loog, level: Logger::INFO) do
       id = post(

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -665,6 +665,13 @@ class TestBazaRbEdge < Minitest::Test
     end
   end
 
+  def test_fee_raises_when_summary_is_empty
+    assert_equal(
+      'The summary "" is empty',
+      assert_raises(RuntimeError) { fake_baza.fee('unknown', 1.0, '', 42) }.message
+    )
+  end
+
   def test_pull_raises_when_id_is_not_integer
     assert_equal('The ID of the job must be an Integer', assert_raises(RuntimeError) { fake_baza.pull(42.5) }.message)
   end


### PR DESCRIPTION
The fee() method in lib/baza-rb.rb guarded against a nil summary but accepted an empty string, so baza.fee('unknown', 1.0, '', 42) reached the server with an empty summary. The transfer() method already rejects both nil and empty on the line above. Mirror that on the fee() method and add an edge test in test/test_baza_edge.rb following the same pattern as test_transfer_raises_when_summary_is_empty.

Closes #401.

---
_Generated by [Claude Code](https://claude.ai/code)_