### PR TITLE
#404: fix malformed Accept header in BazaRb#download

### DIFF
--- a/lib/baza-rb.rb
+++ b/lib/baza-rb.rb
@@ -791,7 +791,7 @@ class BazaRb
                   uri.to_s,
                   method: :get,
                   headers: headers.merge(
-                    'Accept' => '*',
+                    'Accept' => '*/*',
                     'Accept-Encoding' => 'gzip',
                     'Range' => "bytes=#{File.size(file)}-"
                   ),

--- a/test/test_baza_edge.rb
+++ b/test/test_baza_edge.rb
@@ -391,6 +391,19 @@ class TestBazaRbEdge < Minitest::Test
     BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false).push('test', 'data', [])
   end
 
+  def test_download_sends_well_formed_accept_header
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'download.txt')
+      stub_request(:get, 'https://example.org:443/file')
+        .with(headers: { 'Accept' => '*/*' })
+        .to_return(status: 200, body: 'success content', headers: {})
+      baza = BazaRb.new('example.org', 443, '000', loog: Loog::NULL, compress: false)
+      baza.__send__(:download, baza.__send__(:home).append('file'), file)
+      assert_equal('success content', File.read(file))
+    end
+  end
+
   def test_download_retries_on_busy_server
     WebMock.disable_net_connect!
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
## What happens

`BazaRb#download` (lib/baza-rb.rb:782) sends a bare asterisk as the `Accept`
request header: `'Accept' => '*'`. Per RFC 7231 §5.3.2, the value of an
`Accept` header must be a comma-separated list of media ranges, and the
universal media range is spelled `*/*`, not `*`. A standalone `*` does not
match the `media-range` ABNF.

Strict HTTP intermediaries (CDNs, reverse proxies, content-negotiating
servers) may treat a malformed `Accept` value as `*/*` for backward
compatibility, but some implementations reject the request, return 406, or
strip the header entirely — so the binary file can come back with an
unexpected content type, or the request can fail outright.

## What should happen

`Accept` should be a well-formed media range: `*/*`.

## Fix

One-line change at `lib/baza-rb.rb:782`:

```diff
-                    'Accept' => '*',
+                    'Accept' => '*/*',
```

No other call site sets the `Accept` header on outbound requests, so this
does not change behavior for any other caller.

## Test

Added `test_download_sends_well_formed_accept_header` in
`test/test_baza_edge.rb`, which stubs the download request and asserts the
request carries `Accept: */*`.

## Verification

- `bundle exec rubocop lib/baza-rb.rb test/test_baza_edge.rb` — no offenses
- Full test suite run locally: 137 tests, 267 assertions, 0 failures.
  (1 pre-existing, unrelated error in `test_durable_load_from_sinatra` due
  to `/bin/bash` not existing on this NixOS sandbox — not caused by this
  change.)

Closes #404
